### PR TITLE
Removed a duplicated relative path for renamed files

### DIFF
--- a/filebrowser_safe/views.py
+++ b/filebrowser_safe/views.py
@@ -370,7 +370,7 @@ def rename(request):
     # QUERY / PATH CHECK
     query = request.GET
     path = get_path(query.get('dir', ''))
-    filename = os.path.join(query.get('dir', ''), query.get('filename', ''))
+    filename = query.get('filename', '')
     if path is None or filename is None:
         if path is None:
             msg = _('The requested Folder does not exist.')


### PR DESCRIPTION
dir was appearing twice in the original filename when trying to rename files in a subdirectory of the Media Library.
