### PR TITLE
Allow for selectability of folders on FileField and FileBrowseField.

### DIFF
--- a/filebrowser_safe/templatetags/fb_tags.py
+++ b/filebrowser_safe/templatetags/fb_tags.py
@@ -123,7 +123,7 @@ class SelectableNode(template.Node):
         elif filetype and format and filetype not in SELECT_FORMATS[format]:
             selectable = False
         else:
-            selectable = filetype != "Folder"
+            selectable = True
         context['selectable'] = selectable
         return ''
 


### PR DESCRIPTION
The corresponding change when making the default FileField format 'Image' in Mezzanine.

https://github.com/stephenmcd/mezzanine/pull/272
