### PR TITLE
South introspection rules doesn't work

### DIFF
--- a/filebrowser_safe/fields.py
+++ b/filebrowser_safe/fields.py
@@ -121,6 +121,6 @@ class FileBrowseField(Field):
 
 try:
     from south.modelsinspector import add_introspection_rules
-    add_introspection_rules([], ["^filebrowser\.fields\.FileBrowseField"])
+    add_introspection_rules([], ["^filebrowser_safe\.fields\.FileBrowseField"])
 except ImportError:
     pass


### PR DESCRIPTION
For south introspection rules to work with the new name of the project, then '_safe" must be added.
