### PR TITLE
Update url templatetags for Django 1.5.

### DIFF
--- a/filebrowser_safe/templates/filebrowser/append.html
+++ b/filebrowser_safe/templates/filebrowser/append.html
@@ -4,7 +4,7 @@
     <table>
         <caption>{% trans "FileBrowser" %}</caption>
         <tr class="row2">
-            <th scope="row"><a href="{% url fb_browse %}">{% trans "FileBrowser" %}</a></th>
+            <th scope="row"><a href="{% url "fb_browse" %}">{% trans "FileBrowser" %}</a></th>
             <td> </td>
             <td> </td>
         </tr>

--- a/filebrowser_safe/templates/filebrowser/custom_field.html
+++ b/filebrowser_safe/templates/filebrowser/custom_field.html
@@ -5,7 +5,7 @@
 .vFileBrowseField {display:none;}
 </style>
 <input id="{{ final_attrs.id }}" type="text" class="vFileBrowseField" name="{{ final_attrs.name }}" value="{{ value }}" />
-<a style="padding:5px 16px;" href="javascript:FileBrowser.show('{{ final_attrs.id }}', '{% url fb_browse %}?pop=1{% if final_attrs.directory %}&amp;dir={{ final_attrs.directory }}{% endif %}{% if final_attrs.format %}&amp;type={{ final_attrs.format }}{% endif %}');" class="fb_show">
+<a style="padding:5px 16px;" href="javascript:FileBrowser.show('{{ final_attrs.id }}', '{% url "fb_browse" %}?pop=1{% if final_attrs.directory %}&amp;dir={{ final_attrs.directory }}{% endif %}{% if final_attrs.format %}&amp;type={{ final_attrs.format }}{% endif %}');" class="fb_show">
     <img src="{{ final_attrs.search_icon }}" alt="" />
 </a>
 {% ifequal value.filetype "Image" %}

--- a/filebrowser_safe/templates/filebrowser/include/breadcrumbs.html
+++ b/filebrowser_safe/templates/filebrowser/include/breadcrumbs.html
@@ -3,16 +3,16 @@
 
 <span class="media-breadcrumb">
 {% if breadcrumbs or breadcrumbs_title %}
-    <a href="{% url fb_browse %}{% query_string "" "dir,filename,p" %}">{% trans 'Media Library' %}</a> <span>&rsaquo;</span>
+    <a href="{% url "fb_browse" %}{% query_string "" "dir,filename,p" %}">{% trans 'Media Library' %}</a> <span>&rsaquo;</span>
 {% else %}
     {% trans 'Media Library' %}
 {% endif %}
 {% for item in breadcrumbs %}
     {% if not forloop.last %}
-        <a href="{% url fb_browse %}{% query_string "" "dir,filename,p" %}&amp;dir={{ item.1 }}">{{ item.0 }}</a> <span>&rsaquo;</span>
+        <a href="{% url "fb_browse" %}{% query_string "" "dir,filename,p" %}&amp;dir={{ item.1 }}">{{ item.0 }}</a> <span>&rsaquo;</span>
     {% else %}
         {% if breadcrumbs_title %}
-            <a href="{% url fb_browse %}{% query_string "" "dir,filename,p" %}&amp;dir={{ item.1 }}">{{ item.0 }}</a> <span>&rsaquo;</span>
+            <a href="{% url "fb_browse" %}{% query_string "" "dir,filename,p" %}&amp;dir={{ item.1 }}">{{ item.0 }}</a> <span>&rsaquo;</span>
         {% else %}
             {{ item.0 }}
         {% endif %}

--- a/filebrowser_safe/templates/filebrowser/include/filelisting.html
+++ b/filebrowser_safe/templates/filebrowser/include/filelisting.html
@@ -59,13 +59,13 @@
 
     <!-- FILENAME/DIMENSIONS -->
     {% ifequal file.filetype 'Folder' %}
-    <td><b><a href="{% url fb_browse %}{% query_string "" "q,dir,p" %}&amp;dir={{ file.path_relative_directory|urlencode }}">{{ file.filename }}</a></b></td>
+    <td><b><a href="{% url "fb_browse" %}{% query_string "" "q,dir,p" %}&amp;dir={{ file.path_relative_directory|urlencode }}">{{ file.filename }}</a></b></td>
     {% else %}
     <td><b><a href="{{ file.url }}" target="_blank">{{ file.filename }}</a></b></td>
     {% endifequal %}
 
     <!-- RENAME -->
-    <td class="fb_icon"><a href="{% url fb_rename %}{% query_string %}&amp;filename={{ file.filename }}" class="fb_renamelink" title="{% trans 'Rename' %}"></a></td>
+    <td class="fb_icon"><a href="{% url "fb_rename" %}{% query_string %}&amp;filename={{ file.filename }}" class="fb_renamelink" title="{% trans 'Rename' %}"></a></td>
 
     <!-- SIZE -->
     <td>{{ file.filesize|filesizeformat }}</td>
@@ -76,10 +76,10 @@
     <!-- DELETE -->
     <td class="fb_icon">
         {% ifnotequal file.filetype 'Folder' %}
-        <form method="POST" action="{% url fb_delete %}{% query_string %}&amp;filename={{ file.filename }}&amp;filetype={{ file.filetype }}" id="delete-{{ forloop.counter0 }}">{% csrf_token %}</form>
+        <form method="POST" action="{% url "fb_delete" %}{% query_string %}&amp;filename={{ file.filename }}&amp;filetype={{ file.filetype }}" id="delete-{{ forloop.counter0 }}">{% csrf_token %}</form>
         <a href="#" class="fb_deletelink" onclick="if (confirm('{% trans "Are you sure you want to delete this file?" %}')) {$('#delete-{{ forloop.counter0 }}').submit();} return false;" title="{% trans 'Delete File' %}"></a>
         {% else %}
-        <form method="POST" action="{% url fb_delete %}{% query_string %}&amp;filename={{ file.filename }}&amp;filetype={{ file.filetype }}" id="delete-{{ forloop.counter0 }}">{% csrf_token %}</form>
+        <form method="POST" action="{% url "fb_delete" %}{% query_string %}&amp;filename={{ file.filename }}&amp;filetype={{ file.filetype }}" id="delete-{{ forloop.counter0 }}">{% csrf_token %}</form>
         <a href="#" class="fb_deletelink" onclick="if (confirm('{% trans "Are you sure you want to delete this Folder?" %}')) {$('#delete-{{ forloop.counter0 }}').submit();} return false;" title="{% trans 'Delete Folder' %}"></a>
         {% endifnotequal %}
     </td>

--- a/filebrowser_safe/templates/filebrowser/index.html
+++ b/filebrowser_safe/templates/filebrowser/index.html
@@ -51,8 +51,8 @@
 <div id="content-main">
     {% block object-tools %}
     <ul class="object-tools">
-        <li><a href="{% url fb_mkdir %}{% query_string '' 'p' %}">{% trans "New Folder" %}</a></li>
-        <li><a href="{% url fb_upload %}{% query_string '' 'p' %}" class="focus">{% trans "Upload" %}</a></li>
+        <li><a href="{% url "fb_mkdir" %}{% query_string '' 'p' %}">{% trans "New Folder" %}</a></li>
+        <li><a href="{% url "fb_upload" %}{% query_string '' 'p' %}" class="focus">{% trans "Upload" %}</a></li>
     </ul>
     {% endblock %}
     <div class="module filtered" id="changelist">

--- a/filebrowser_safe/templates/filebrowser/upload.html
+++ b/filebrowser_safe/templates/filebrowser/upload.html
@@ -22,16 +22,16 @@
     <script type="text/javascript" src="{% admin_media_prefix %}js/admin/CollapsedFieldsets.js"></script>
     <script type="text/javascript">
     $(document).ready(function() {
-        {% url static_proxy as static_proxy_url %}
+        {% url "static_proxy" as static_proxy_url %}
         var proxy = '{{ static_proxy_url }}';
         if (proxy) {
             proxy += '?u=';
         }
         $('#id_file').uploadify({
             'uploader'          : proxy + '{{ settings_var.URL_FILEBROWSER_MEDIA }}uploadify/uploadify.swf',
-            'script'            : '{% url fb_do_upload %}',
+            'script'            : '{% url "fb_do_upload" %}',
             'scriptData'        : {'session_key': '{{session_key}}'},
-            'checkScript'       : '{% url fb_check %}',
+            'checkScript'       : '{% url "fb_check" %}',
             'cancelImg'         : '{{ settings_var.URL_FILEBROWSER_MEDIA }}uploadify/cancel.png',
             'auto'              : false,
             'folder'            : '{{ query.dir|escapejs }}',
@@ -47,7 +47,7 @@
             'hideButton'        : false,
             'wmode'             : 'transparent',
             'removeCompleted'   : false,
-            'onAllComplete' : function(event,data) {location = '{% url fb_browse %}{% query_string '' 'p' %}'},
+            'onAllComplete' : function(event,data) {location = '{% url "fb_browse" %}{% query_string '' 'p' %}'},
             translations        : {
                                   browseButton: '{% trans "BROWSE" %}',
                                   error: '{% trans "An Error occured" %}',


### PR DESCRIPTION
See https://docs.djangoproject.com/en/1.4/releases/1.3/#changes-to-url-and-ssi

Here `{% load url from future %}` is omitted in favour of a global import in mezzanine's `boot/__init__.py` - see stephenmcd/mezzanine#394.

This technically introduces a dependency on Mezzanine. Since filebrowser_safe is packaged specifically for Mezzanine and its use anywhere else is unsupported, I think that's acceptable.
