### PR TITLE
Fixes the broken setting FILEBROWSER_NORMALIZE_FILENAME

### DIFF
--- a/filebrowser_safe/views.py
+++ b/filebrowser_safe/views.py
@@ -289,7 +289,6 @@ def _upload_file(request):
 
         if request.FILES:
             filedata = request.FILES['Filedata']
-            abs_path = os.path.join(DIRECTORY, folder, filedata.name)
             # PRE UPLOAD SIGNAL
             filebrowser_pre_upload.send(sender=request, path=request.POST.get('folder'), file=filedata)
 
@@ -297,6 +296,7 @@ def _upload_file(request):
 
             # HANDLE UPLOAD
             exists = default_storage.exists(os.path.join(DIRECTORY, folder, filedata.name))
+            abs_path = os.path.join(DIRECTORY, folder, filedata.name)
             uploadedfile = default_storage.save(abs_path, filedata)
 
             path = os.path.join(DIRECTORY, folder)


### PR DESCRIPTION
The absolute path to where the file is stored was set before convert_filename method had the chance to normalize the filename. This fixes #18.
