### PR TITLE
Clear FileField fixes

### DIFF
--- a/filebrowser_safe/static/filebrowser/js/AddFileBrowser.js
+++ b/filebrowser_safe/static/filebrowser/js/AddFileBrowser.js
@@ -28,9 +28,8 @@ var FileBrowser = {
         }
     },
     clear: function(id) {
-        var id2=String(id).replace(/\-/g,"____").split(".").join("___");
-        $('#help_'+id2+', #clear_'+id2).hide();
-        $('#'+id2).val('');
+        $('#help_'+id+', #clear_'+id).hide();
+        $('#'+id).val('');
     }
 }
 

--- a/filebrowser_safe/static/filebrowser/js/FB_FileBrowseField.js
+++ b/filebrowser_safe/static/filebrowser/js/FB_FileBrowseField.js
@@ -5,12 +5,18 @@ function FileSubmit(FileURL, ThumbURL, FileType) {
     var preview_id = 'image_' + input_id;
     var link_id = 'link_' + input_id;
     var help_id = 'help_' + input_id;
+    var clear_id = 'clear_' + input_id;
     input = opener.document.getElementById(input_id);
     preview = opener.document.getElementById(preview_id);
     link = opener.document.getElementById(link_id);
     help = opener.document.getElementById(help_id);
+    clear = opener.document.getElementById(clear_id);
+
     // set new value for input field
     input.value = FileURL;
+
+    // enable the clear "button"
+    $(clear).css("display", "inline");
 
     if (ThumbURL && FileType != "") {
         // selected file is an image and thumbnail is available:

--- a/filebrowser_safe/templates/filebrowser/custom_field.html
+++ b/filebrowser_safe/templates/filebrowser/custom_field.html
@@ -22,11 +22,9 @@
 </p>
 {% endifequal %}
 {% if not self.is_required %}
-    {% if value %}
-    <p class="help mezz-fb-clear" id="clear_{{ final_attrs.id }}" style="display:inline; margin:0 10px;">
+    <p class="help mezz-fb-clear" id="clear_{{ final_attrs.id }}" style="display:{% if value %}inline{% else %}none{% endif %}; margin:0 10px;">
         <a href="javascript:FileBrowser.clear('{{ final_attrs.id }}');">{% trans "Clear" %}</a>
     </p>
-    {% endif %}
 {% endif %}
 {% if final_attrs.DEBUG %}
 <p>


### PR DESCRIPTION
Fixes a couple of issues with the Clear link on the FileField:
1) Strangely, it wasn't working at all. It was trying to hide the preview and itself using the wrong element IDs.
2) On new model instances, clear would not appear until the instance was saved.
