### PR TITLE
Unlocalize MAX_UPLOAD_SIZE setting in upload.html

### DIFF
--- a/filebrowser_safe/templates/filebrowser/upload.html
+++ b/filebrowser_safe/templates/filebrowser/upload.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 
 <!-- LOADING -->
-{% load i18n future static fb_tags mezzanine_tags %}
+{% load i18n l10n future static fb_tags mezzanine_tags %}
 
 <!-- STYLESHEETS -->
 {% block stylesheets %}
@@ -36,7 +36,7 @@
             'multi'             : true,
             'fileDesc'          : '{% for extension in settings_var.EXTENSIONS.items %}{% ifnotequal extension.0 'Folder' %}{% for item in extension.1 %}*{{ item|safe }};{% endfor %}{% endifnotequal %}{% endfor %}',
             'fileExt'           : '{% for extension in settings_var.EXTENSIONS.items %}{% ifnotequal extension.0 'Folder' %}{% for item in extension.1 %}*{{ item|safe }};{% endfor %}{% endifnotequal %}{% endfor %}',
-            'sizeLimit'         : {{ settings_var.MAX_UPLOAD_SIZE }},
+            'sizeLimit'         : {{ settings_var.MAX_UPLOAD_SIZE|unlocalize }},
             'scriptAccess'      : 'always',
             'queueSizeLimit'    : 50,
             'simUploadLimit'    : 1,


### PR DESCRIPTION
Unlocalized MAX_UPLOAD_SIZE setting which is passed to uploadify in upload.html template, which can create problems when thousand separator is used.
