### PR TITLE
Fix Custom Field Thumbnail Link

### DIFF
--- a/filebrowser_safe/templates/filebrowser/custom_field.html
+++ b/filebrowser_safe/templates/filebrowser/custom_field.html
@@ -10,7 +10,7 @@
 </a>
 {% ifequal value.filetype "Image" %}
 <p class="help mezz-fb-thumbnail" id="help_{{ final_attrs.id }}">
-    <a href="{{ value.url_full }}" target="_blank" id="link_{{ final_attrs.id }}">
+    <a href="{{ value.url }}" target="_blank" id="link_{{ final_attrs.id }}">
         <img id="image_{{ final_attrs.id }}" src="{{ MEDIA_URL }}{% thumbnail value.path 60 60 %}" class="preview" />
     </a>
 </p>


### PR DESCRIPTION
The `url_full` property doesn't work, and everywhere else we use `url`.
