### PR TITLE
Thumbnail link is broken when file is initially added, and only works after the model has been saved.

### DIFF
--- a/filebrowser_safe/static/filebrowser/js/FB_FileBrowseField.js
+++ b/filebrowser_safe/static/filebrowser/js/FB_FileBrowseField.js
@@ -1,4 +1,4 @@
-function FileSubmit(FileURL, ThumbURL, FileType) {
+function FileSubmit(FilePath, FileURL, ThumbURL, FileType) {
 
     // var input_id=window.name.split("___").join(".");
     var input_id=window.name.replace(/____/g,'-').split("___").join(".");
@@ -13,7 +13,7 @@ function FileSubmit(FileURL, ThumbURL, FileType) {
     clear = opener.document.getElementById(clear_id);
 
     // set new value for input field
-    input.value = FileURL;
+    input.value = FilePath;
 
     // enable the clear "button"
     $(clear).css("display", "inline");

--- a/filebrowser_safe/templates/filebrowser/include/filelisting.html
+++ b/filebrowser_safe/templates/filebrowser/include/filelisting.html
@@ -15,7 +15,7 @@ h1 {margin:-30px 0 15px 0;}
     <td class="fb_icon">
         {% selectable file.filetype query.type %}
         {% if selectable %}
-        <a href="javascript://" onclick="FileSubmit('{{ file.path }}', '{{ MEDIA_URL }}{% ifequal file.filetype 'Image' %}{% thumbnail file.path 60 60 %}{% else %}{{ file.path }}{% endifequal %}', '{{ file.filetype }}');" class="fb_selectlink" title="{% trans 'Select' %}"></a>
+        <a href="javascript://" onclick="FileSubmit('{{ file.path }}', '{{ file.url }}', '{{ MEDIA_URL }}{% ifequal file.filetype 'Image' %}{% thumbnail file.path 60 60 %}{% else %}{{ file.path }}{% endifequal %}', '{{ file.filetype }}');" class="fb_selectlink" title="{% trans 'Select' %}"></a>
         {% else %}
         <img src="{{ settings_var.URL_FILEBROWSER_MEDIA }}img/filebrowser_icon_select_disabled.gif" width="23" height="17" />
         {% endif %}


### PR DESCRIPTION
The javascript for selecting a file sets the thumbnail link to the relative path of the file instead of the full url. Since the input element does actually need the relative path, we must pass both the relative path and the url to the SubmitFile function.
