### PR TITLE
Add support for django-s3-storage-folder

### DIFF
--- a/filebrowser_safe/views.py
+++ b/filebrowser_safe/views.py
@@ -38,6 +38,11 @@ from mezzanine.utils.importing import import_dotted_path
 # Add some required methods to FileSystemStorage
 storage_class_name = django_settings.DEFAULT_FILE_STORAGE.split(".")[-1]
 mixin_class_name = "filebrowser_safe.storage.%sMixin" % storage_class_name
+
+# Workaround for django-s3-folder-storage
+if django_settings.DEFAULT_FILE_STORAGE == 's3_folder_storage.s3.DefaultStorage':
+    mixin_class_name = 'filebrowser_safe.storage.S3BotoStorageMixin'
+
 try:
     mixin_class = import_dotted_path(mixin_class_name)
     storage_class = import_dotted_path(django_settings.DEFAULT_FILE_STORAGE)


### PR DESCRIPTION
Fixes a bug when using [django-s3-storage-folder](https://pypi.python.org/pypi/django-s3-folder-storage/), where filebrowser-safe will not set the appropriate StorageMixin because it doesn't recognize 's3_folder_storage.s3.DefaultStorage' as a valid value for DEFAULT_FILE_STORAGE.

Specifically, filebrowser-safe looks for filebrowser_safe.storage.DefaultStorageMixin, which doesn't exist. This leads to errors that look like:

```
AttributeError at /admin/storepage/storepage/131/
'DefaultStorage' object has no attribute 'isdir'
```

As a workaround, instead of defining a storage.DefaultStorageMixin class (which would have a misleading name, since it's not the default storage mixin), we just treat this as a special case and use the storage.S3BotoStorageMixin if we detect that django-s3-storage-folder is used.
