### PR TITLE
Correct addEvent function

### DIFF
--- a/filebrowser_safe/static/filebrowser/js/AddFileBrowser.js
+++ b/filebrowser_safe/static/filebrowser/js/AddFileBrowser.js
@@ -33,13 +33,18 @@ var FileBrowser = {
     }
 }
 
-function addEvent( obj, type, fn ) {
-    if ( obj.attachEvent ) {
-        obj['e'+type+fn] = fn;
-        obj[type+fn] = function(){obj['e'+type+fn]( window.event );}
-        obj.attachEvent( 'on'+type, obj[type+fn] );
-    } else
-        obj.addEventListener( type, fn, false );
+if (!addEvent){
+    function addEvent(obj, evType, fn) {
+        if (obj.addEventListener) {
+            obj.addEventListener(evType, fn, false);
+            return true;
+        } else if (obj.attachEvent) {
+            var r = obj.attachEvent("on" + evType, fn);
+            return r;
+        } else {
+            return false;
+        }
+    }
 }
 
 addEvent(window, 'load', FileBrowser.init);


### PR DESCRIPTION
Use django's default addEvent implementation (in contrib/admin/static/admin/js/core.js), or if not provided then define our own based on django's implementation. This fixes a bug that occurs when there are multiple horizontal filtered many-to-many fields on an admin in IE10 (and perhaps other versions of IE).
