### PR TITLE
Adding support for Callables to be passed in for directory

### DIFF
--- a/filebrowser_safe/fields.py
+++ b/filebrowser_safe/fields.py
@@ -44,7 +44,9 @@ class FileBrowseWidget(Input):
             value = ""
         directory = self.directory
         if self.directory:
-            directory = os.path.normpath(datetime.datetime.now().strftime(self.directory))
+            if callable(self.directory):
+                directory = self.directory()
+            directory = os.path.normpath(datetime.datetime.now().strftime(directory))
             fullpath = os.path.join(get_directory(), directory)
             if not default_storage.isdir(fullpath):
                 default_storage.makedirs(fullpath)


### PR DESCRIPTION
I added a check and execution of a Callable to be passed in. This allows the UPLOAD_TO_HANDLERS to work in the settings file at overriding the default location where FileBrowseField shows upon opening.
