### PR TITLE
Improve default EXTENSIONS.

### DIFF
--- a/filebrowser_safe/settings.py
+++ b/filebrowser_safe/settings.py
@@ -43,9 +43,9 @@ PATH_TINYMCE = getattr(settings, "FILEBROWSER_PATH_TINYMCE", DEFAULT_PATH_TINYMC
 EXTENSIONS = getattr(settings, "FILEBROWSER_EXTENSIONS", {
     'Folder': [''],
     'Image': ['.jpg', '.jpeg', '.gif', '.png', '.tif', '.tiff', '.svg'],
-    'Video': ['.mov', '.wmv', '.mpeg', '.mpg', '.avi', '.rm'],
-    'Document': ['.pdf', '.doc', '.rtf', '.txt', '.xls', '.csv'],
-    'Audio': ['.mp3', '.mp4', '.wav', '.aiff', '.midi', '.m4p'],
+    'Video': ['.mov', '.wmv', '.mpeg', '.mpg', '.avi', '.rm', '.mp4'],
+    'Document': ['.pdf', '.doc', '.rtf', '.txt', '.xls', '.csv', '.docx'],
+    'Audio': ['.mp3', '.wav', '.aiff', '.midi', '.m4p'],
     'Code': ['.html', '.py', '.js', '.css']
 })
 


### PR DESCRIPTION
- mp4 is primarily a video format. It's what youtube uses.
- add docx