### PR TITLE
Handle sorting when date or filesize is None (happens for folders in S3)

### DIFF
--- a/filebrowser_safe/views.py
+++ b/filebrowser_safe/views.py
@@ -156,7 +156,10 @@ def browse(request):
     # SORTING
     query['o'] = request.GET.get('o', DEFAULT_SORTING_BY)
     query['ot'] = request.GET.get('ot', DEFAULT_SORTING_ORDER)
-    files = sorted(files, key=lambda f: getattr(f, request.GET.get('o', DEFAULT_SORTING_BY)))
+    defaultValue = ''
+    if query['o'] in ['date', 'filesize']:
+        defaultValue = 0.0
+    files = sorted(files, key=lambda f: getattr(f, query['o']) or defaultValue)
     if not request.GET.get('ot') and DEFAULT_SORTING_ORDER == "desc" or request.GET.get('ot') == "desc":
         files.reverse()
 


### PR DESCRIPTION
I was running into an issue using Amazon S3. One folder was fine (no comparison being done), but when I had two folders, or a folder and a file, the comparison failed and the page crashed. I noticed that for folders, the file objects being pulled from S3 has date=None and filesize=None. This code will handle that situation.