### PR TITLE
Make FileBrowseField return a FieldFile. Fix #69.

### DIFF
--- a/filebrowser_safe/base.py
+++ b/filebrowser_safe/base.py
@@ -20,19 +20,8 @@ except ImportError:
 from filebrowser_safe.functions import get_file_type, path_strip, get_directory
 
 
-class FileObjectMixin(object):
-    """
-    The FileObject represents a file (or directory) on the server.
-
-    An example::
-
-        from filebrowser.base import FileObject
-
-        fileobject = FileObject(path)
-
-    where path is a relative path to a storage location.
-    """
-
+class FileObjectAPI(object):
+    """ A mixin class providing file properties. """
     def __init__(self, path):
         self.head = os.path.dirname(path)
         self.filename = os.path.basename(path)
@@ -144,7 +133,18 @@ class FileObjectMixin(object):
                 pass
 
 
-class FileObject(FileObjectMixin):
+class FileObject(FileObjectAPI):
+    """
+    The FileObject represents a file (or directory) on the server.
+
+    An example::
+
+        from filebrowser.base import FileObject
+
+        fileobject = FileObject(path)
+
+    where path is a relative path to a storage location.
+    """
     def __init__(self, path):
         self.path = path
         super(FileObject, self).__init__(path)
@@ -154,14 +154,14 @@ class FileObject(FileObjectMixin):
         return self.path
 
 
-class FieldFileObject(FieldFile, FileObjectMixin):
+class FieldFileObject(FieldFile, FileObjectAPI):
     """
     Returned when a FileBrowseField is accessed on a model instance.
 
-    - Implements the FieldFile API for interoperability with other django
-    reusable apps.
+    - Implements the FieldFile API so FileBrowseField can act as substitute for
+    django's built-in FileField.
     - Implements the FileObject API for historical reasons.
     """
     def __init__(self, instance, field, path):
         FieldFile.__init__(self, instance, field, path)
-        FileObjectMixin.__init__(self, path)
+        FileObjectAPI.__init__(self, path)

--- a/filebrowser_safe/base.py
+++ b/filebrowser_safe/base.py
@@ -164,4 +164,4 @@ class FieldFileObject(FieldFile, FileObjectAPI):
     """
     def __init__(self, instance, field, path):
         FieldFile.__init__(self, instance, field, path)
-        FileObjectAPI.__init__(self, path)
+        FileObjectAPI.__init__(self, path or '')

--- a/filebrowser_safe/base.py
+++ b/filebrowser_safe/base.py
@@ -63,13 +63,13 @@ class FileObjectMixin(object):
 
     @cached_property
     def filesize(self):
-        if self.exists():
+        if self.exists:
             return default_storage.size(self.path)
         return None
 
     @cached_property
     def date(self):
-        if self.exists():
+        if self.exists:
             return time.mktime(
                 default_storage.modified_time(self.path).timetuple())
         return None
@@ -81,11 +81,8 @@ class FileObjectMixin(object):
         return None
 
     @cached_property
-    def _exists(self):
-        return default_storage.exists(self.path)
-
     def exists(self):
-        return self._exists
+        return default_storage.exists(self.path)
 
     # PATH/URL ATTRIBUTES
 

--- a/filebrowser_safe/functions.py
+++ b/filebrowser_safe/functions.py
@@ -13,7 +13,6 @@ from time import gmtime, strftime, localtime, time
 
 # django imports
 from django.utils import six
-from django.contrib.sites.models import Site
 from django.core.files.storage import default_storage
 
 # filebrowser imports
@@ -45,19 +44,6 @@ def path_strip(path, root):
     if path.startswith(root):
         return path[len(root):]
     return path
-
-
-def url_to_path(value):
-    """
-    Change URL to PATH.
-    Value has to be an URL relative to MEDIA URL or a full URL (including MEDIA_URL).
-
-    Returns a PATH relative to MEDIA_ROOT.
-    """
-
-    mediaurl_re = re.compile(r'^(%s)' % (MEDIA_URL))
-    value = mediaurl_re.sub('', value)
-    return value
 
 
 def path_to_url(value):


### PR DESCRIPTION
See the docs on
[FileField and FieldFile](https://docs.djangoproject.com/en/1.9/ref/models/fields/#filefield-and-fieldfile):

> When you access a FileField on a model, you are given an instance of
> FieldFile as a proxy for accessing the underlying file.

Implementation Details
----------------------

- Use the same descriptor mechanism upstream `FileField` uses to return
  a specific class of object rather than the `from_db_value`/`to_python`
  methods. These won't work because `FieldFile` needs to be instantiated
  with a model instance, which these methods do not have access to.
- Break most of `FileObject` out into `FileObjectMixin` so it can be
  subclassed. We need a separate class for compatibility with
  `FieldFile` because each one has a `property` with no setter that the
  other implements as an instance attribute, which causes
  `AttributeError`'s. (See http://stackoverflow.com/a/27627094/1938621).