### PR TITLE
Fix "The requested Folder does not exist" message.

### DIFF
--- a/filebrowser_safe/fields.py
+++ b/filebrowser_safe/fields.py
@@ -51,11 +51,6 @@ class FileBrowseWidget(Input):
         final_attrs['format'] = self.format
         final_attrs['ADMIN_THUMBNAIL'] = ADMIN_THUMBNAIL
         final_attrs['DEBUG'] = DEBUG
-        if value != "":
-            try:
-                final_attrs['directory'] = os.path.split(value.path_relative_directory)[0]
-            except:
-                pass
         return render_to_string("filebrowser/custom_field.html", dict(locals(), MEDIA_URL=MEDIA_URL))
 
 


### PR DESCRIPTION
When I go to edit a FileBrowseField on an existing model, this error
message is flashed and it goes to the root media directory rather than
whatever directory the file is in.

The reason for this is that this code replaces the directory with an
absolute path. I have no idea why. The fb_browse view clearly expects a
relative path:

    abs_path = os.path.join(get_directory(), path)