### PR TITLE
Drop deprecated future templatetag library

### DIFF
--- a/filebrowser_safe/templates/filebrowser/include/filelisting.html
+++ b/filebrowser_safe/templates/filebrowser/include/filelisting.html
@@ -1,4 +1,4 @@
-{% load i18n future static fb_tags mezzanine_tags %}
+{% load i18n static fb_tags mezzanine_tags %}
 
 {% if query.pop %}
 <style>

--- a/filebrowser_safe/templates/filebrowser/index.html
+++ b/filebrowser_safe/templates/filebrowser/index.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 
 <!-- LOADING -->
-{% load i18n future static fb_tags fb_pagination %}
+{% load i18n static fb_tags fb_pagination %}
 
 <!-- STYLESHEETS -->
 {% block stylesheets %}

--- a/filebrowser_safe/templates/filebrowser/upload.html
+++ b/filebrowser_safe/templates/filebrowser/upload.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 
 <!-- LOADING -->
-{% load i18n l10n future static fb_tags mezzanine_tags %}
+{% load i18n l10n static fb_tags mezzanine_tags %}
 
 <!-- STYLESHEETS -->
 {% block stylesheets %}


### PR DESCRIPTION
Don't load url from the `future` templatetag library, it was [removed in Django 1.9](https://docs.djangoproject.com/en/1.9/releases/1.9/#features-removed-in-1-9).
