### PR TITLE
Remove unused imports

### DIFF
--- a/filebrowser_safe/functions.py
+++ b/filebrowser_safe/functions.py
@@ -1,19 +1,15 @@
 from __future__ import unicode_literals
 from future.builtins import int
-from future.builtins import range
-from future.builtins import map
 from future.builtins import str
 # coding: utf-8
 
 # imports
-import os
 import re
 import unicodedata
 from time import gmtime, strftime, localtime, time
 
 # django imports
 from django.utils import six
-from django.contrib.sites.models import Site
 from django.core.files.storage import default_storage
 
 # filebrowser imports


### PR DESCRIPTION
When models are imported as a side-effect of importing a field used in Mezzanine's EXTRA_MODEL_FIELDS, migrations breaks. Fortunately the import of Site in this file wasn't actually used so we can just drop it.

See https://github.com/stephenmcd/mezzanine/issues/1513