### PR TITLE
Prune Settings

### DIFF
--- a/filebrowser_safe/fields.py
+++ b/filebrowser_safe/fields.py
@@ -50,7 +50,6 @@ class FileBrowseWidget(Input):
         final_attrs['directory'] = directory
         final_attrs['extensions'] = self.extensions
         final_attrs['format'] = self.format
-        final_attrs['ADMIN_THUMBNAIL'] = ADMIN_THUMBNAIL
         final_attrs['DEBUG'] = settings.DEBUG
         return render_to_string("filebrowser/custom_field.html", dict(locals(), MEDIA_URL=MEDIA_URL))
 

--- a/filebrowser_safe/fields.py
+++ b/filebrowser_safe/fields.py
@@ -5,6 +5,7 @@ import os
 import datetime
 
 from django import forms
+from django.conf import settings
 from django.core.files.storage import default_storage
 from django.db.models.fields import Field
 from django.db.models.fields.files import FileDescriptor
@@ -50,7 +51,7 @@ class FileBrowseWidget(Input):
         final_attrs['extensions'] = self.extensions
         final_attrs['format'] = self.format
         final_attrs['ADMIN_THUMBNAIL'] = ADMIN_THUMBNAIL
-        final_attrs['DEBUG'] = DEBUG
+        final_attrs['DEBUG'] = settings.DEBUG
         return render_to_string("filebrowser/custom_field.html", dict(locals(), MEDIA_URL=MEDIA_URL))
 
 

--- a/filebrowser_safe/functions.py
+++ b/filebrowser_safe/functions.py
@@ -170,11 +170,6 @@ def get_settings_var():
     # Extensions/Formats (for FileBrowseField)
     settings_var['EXTENSIONS'] = EXTENSIONS
     settings_var['SELECT_FORMATS'] = SELECT_FORMATS
-    # Versions
-    settings_var['VERSIONS_BASEDIR'] = VERSIONS_BASEDIR
-    settings_var['VERSIONS'] = VERSIONS
-    settings_var['ADMIN_VERSIONS'] = ADMIN_VERSIONS
-    settings_var['ADMIN_THUMBNAIL'] = ADMIN_THUMBNAIL
     # FileBrowser Options
     settings_var['MAX_UPLOAD_SIZE'] = MAX_UPLOAD_SIZE
     # Convert Filenames

--- a/filebrowser_safe/functions.py
+++ b/filebrowser_safe/functions.py
@@ -10,6 +10,7 @@ from time import gmtime, strftime, localtime, time
 
 # django imports
 from django.utils import six
+from django.conf import settings
 from django.core.files.storage import default_storage
 
 # filebrowser imports
@@ -156,7 +157,7 @@ def get_settings_var():
 
     settings_var = {}
     # Main
-    settings_var['DEBUG'] = DEBUG
+    settings_var['DEBUG'] = settings.DEBUG
     settings_var['MEDIA_ROOT'] = MEDIA_ROOT
     settings_var['MEDIA_URL'] = MEDIA_URL
     settings_var['DIRECTORY'] = get_directory()

--- a/filebrowser_safe/settings.py
+++ b/filebrowser_safe/settings.py
@@ -61,29 +61,6 @@ SELECT_FORMATS = {
 }
 SELECT_FORMATS.update(getattr(settings, "FILEBROWSER_SELECT_FORMATS", {}))
 
-# Directory to Save Image Versions (and Thumbnails). Relative to MEDIA_ROOT.
-# If no directory is given, versions are stored within the Image directory.
-# VERSION URL: VERSIONS_BASEDIR/original_path/originalfilename_versionsuffix.extension
-VERSIONS_BASEDIR = getattr(settings, 'FILEBROWSER_VERSIONS_BASEDIR', '')
-# Versions Format. Available Attributes: verbose_name, width, height, opts
-VERSIONS = getattr(settings, "FILEBROWSER_VERSIONS", {})
-
-# VERSIONS = getattr(settings, "FILEBROWSER_VERSIONS", {
-#     'fb_thumb': {'verbose_name': 'Admin Thumbnail', 'width': 60, 'height': 60, 'opts': 'crop upscale'},
-#     'thumbnail': {'verbose_name': 'Thumbnail (140px)', 'width': 140, 'height': '', 'opts': ''},
-#     'small': {'verbose_name': 'Small (300px)', 'width': 300, 'height': '', 'opts': ''},
-#     'medium': {'verbose_name': 'Medium (460px)', 'width': 460, 'height': '', 'opts': ''},
-#     'big': {'verbose_name': 'Big (620px)', 'width': 620, 'height': '', 'opts': ''},
-#     'cropped': {'verbose_name': 'Cropped (60x60px)', 'width': 60, 'height': 60, 'opts': 'crop'},
-#     'croppedthumbnail': {'verbose_name': 'Cropped Thumbnail (140x140px)', 'width': 140, 'height': 140, 'opts': 'crop'},
-# })
-# Versions available within the Admin-Interface.
-ADMIN_VERSIONS = getattr(settings,
-                         'FILEBROWSER_ADMIN_VERSIONS',
-                         ['thumbnail', 'small', 'medium', 'big'])
-# Which Version should be used as Admin-thumbnail.
-ADMIN_THUMBNAIL = getattr(settings, 'FILEBROWSER_ADMIN_THUMBNAIL', 'fb_thumb')
-
 # EXTRA SETTINGS
 # True to save the URL including STATIC_URL to your model fields
 # or False (default) to save path relative to STATIC_URL.

--- a/filebrowser_safe/settings.py
+++ b/filebrowser_safe/settings.py
@@ -17,9 +17,6 @@ except ImportError:
     DEFAULT_URL_TINYMCE = settings.STATIC_URL + "grappelli/tinymce/jscripts/tiny_mce/"
     DEFAULT_PATH_TINYMCE = os.path.join(settings.MEDIA_ROOT, 'admin/tinymce/jscripts/tiny_mce/')
 
-# Set to True in order to see the FileObject when Browsing.
-DEBUG = getattr(settings, "FILEBROWSER_DEBUG", False)
-
 # Main Media Settings
 MEDIA_ROOT = getattr(settings, "FILEBROWSER_MEDIA_ROOT", settings.MEDIA_ROOT)
 MEDIA_URL = getattr(settings, "FILEBROWSER_MEDIA_URL", settings.MEDIA_URL)

--- a/filebrowser_safe/templates/filebrowser/include/tableheader.html
+++ b/filebrowser_safe/templates/filebrowser/include/tableheader.html
@@ -7,10 +7,6 @@
     {% ifequal query.pop '3' %}{% if results_var.select_total %}<th></th>{% endif %}{% endifequal %}
     {% ifequal query.pop '4' %}{% if results_var.select_total %}<th></th>{% endif %}{% endifequal %}
     {% ifequal query.pop '5' %}{% if results_var.select_total %}<th></th>{% endif %}{% endifequal %}
-    <!-- SHOW VERSIONS -->
-    {% comment %}
-    {% if results_var.images_total and settings_var.ADMIN_VERSIONS %}<th>&nbsp;</th>{% endif %}
-    {% endcomment %}
     <!-- FILETYPE -->
     {% ifequal query.o 'filetype' %}<th class="sorted {{ query.ot }}ending"><a href="{% query_string "" "o,ot,p" %}&amp;ot={% ifequal query.ot 'desc' %}asc{% else %}desc{% endifequal %}&amp;o=filetype"></a></th>{% endifequal %}
     {% ifnotequal query.o 'filetype' %}<th><a href="{% query_string "" "o,ot,p" %}&amp;ot=asc&amp;o=filetype">&nbsp;</a></th>{% endifnotequal %}

--- a/filebrowser_safe/views.py
+++ b/filebrowser_safe/views.py
@@ -57,12 +57,7 @@ else:
 
 
 # Precompile regular expressions
-filter_re = []
-for exp in EXCLUDE:
-    filter_re.append(re.compile(exp))
-for k, v in VERSIONS.items():
-    exp = (r'_%s.(%s)') % (k, '|'.join(EXTENSION_LIST))
-    filter_re.append(re.compile(exp))
+filter_re = [re.compile(exp) for exp in EXCLUDE]
 
 
 def remove_thumbnails(file_path):
@@ -110,7 +105,7 @@ def browse(request):
     files = []
     for file in dir_list + file_list:
 
-        # EXCLUDE FILES MATCHING VERSIONS_PREFIX OR ANY OF THE EXCLUDE PATTERNS
+        # EXCLUDE FILES MATCHING ANY OF THE EXCLUDE PATTERNS
         filtered = not file or file.startswith('.')
         for re_prefix in filter_re:
             if re_prefix.search(file):


### PR DESCRIPTION
Note that the DEBUG change does change behavior -- the debug column now shows up in filebrowser when `DEBUG == True`. I think this is fine but you may disagree.

There may be more settings that can be eliminated but these looked like the easiest targets. I'm thinking converting the remainder to registered mezzanine settings would make it easier to add them to merge them into the mezzanine configuration docs.