### PR TITLE
Allow multiple file selection when uploading

### DIFF
--- a/filebrowser_safe/static/filebrowser/css/filebrowser.css
+++ b/filebrowser_safe/static/filebrowser/css/filebrowser.css
@@ -104,24 +104,26 @@ table .fb_showversionslink:hover, table .fb_showversionslink:active { background
 .file-input-wrapper .error{
     color: #f00;
 }
-
+.file-input-result {
+    margin: .5em 0;
+}
 /*
     note that some browsers don't allow
     input[type="file"] to be display:none
 */
 .file-input-wrapper input[type="file"],
 .file-input-wrapper .hide,
-.file-input-wrapper.selected .hide-selected,
-.file-input-wrapper.in-progress .hide-in-progress,
-.file-input-wrapper.done .hide-done{
+.file-input-result.selected .hide-selected,
+.file-input-result.in-progress .hide-in-progress,
+.file-input-result.done .hide-done{
     position: absolute;
     top: 0;
     left: -9999em;
 }
 
-.file-input-wrapper.selected .show-selected,
-.file-input-wrapper.in-progress .show-in-progress,
-.file-input-wrapper.done .show-done{
+.file-input-result.selected .show-selected,
+.file-input-result.in-progress .show-in-progress,
+.file-input-result.done .show-done{
     position: relative;
     top: auto;
     left: auto;

--- a/filebrowser_safe/templates/filebrowser/upload.html
+++ b/filebrowser_safe/templates/filebrowser/upload.html
@@ -49,23 +49,20 @@
     <div>
         <fieldset class="module aligned">
         <div class="form-row">
-            <div>
-                <div class="file-input-wrapper">
-                    <label class="button hide-in-progress hide-done">
-                        {% trans 'Browse' %}
-                        <input name="Filedata" type="file" />
-                    </label>
-
+            <div class="file-input-wrapper">
+                <div class="file-input-result">
                     <div class="progress hide show-in-progress show-done">
                         <div class="progress-inner"></div>
                     </div>
-
                     <div class="button button-error cancel-button hide show-selected">
-                        {% trans 'Clear' %}
+                        {% trans 'Remove' %}
                     </div>
-
                     <span class="status hide show-selected show-in-progress show-done"></span>
                 </div>
+                <label class="button hide-in-progress hide-done">
+                    {% trans 'Browse' %}
+                    <input name="Filedata" type="file" multiple />
+                </label>
             </div>
 
             {% csrf_token %}


### PR DESCRIPTION
Fix for issue #89: HTML 5 uploader doesn't allow multiple selection of
files

- Changed file selection dialog to a multiple-select enabled dialog
- Updated the processing after file selection to add a row for each
selected file, each with a Remove button to remove that file from the queue
- There is now a single Browse button, rather than one on each row. It can be clicked multiple times to keep adding more files to the queue.
- As before, files are not actually uploaded until Upload button is pressed.

Tested on 
OSX 10.11.6:
- FireFox 49.0
- Chrome 53.0
- Safari 9.1.2

Windows 7
- IE 11

Sneak peek:
<img width="335" alt="screenshot" src="https://cloud.githubusercontent.com/assets/5060189/19173630/a81b2b74-8bf6-11e6-8c49-47ff15246a4f.png">