### PR TITLE
Add language classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,11 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
+    classifiers=[
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+    ],
 )


### PR DESCRIPTION
Without language classifiers this project gets incorrectly marked as not supporting Python3 by tools like `caniusepython3` and [caniusepython3.com](https://caniusepython3.com/project/filebrowser_safe). Seems trivial enough to just add them (and any other classifiers you want while we're in there).