### PR TITLE
Remove tinymce import. Resolve #96.

### DIFF
--- a/filebrowser_safe/settings.py
+++ b/filebrowser_safe/settings.py
@@ -8,14 +8,8 @@ import os
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
-# settings for django-tinymce
-try:
-    import tinymce.settings
-    DEFAULT_URL_TINYMCE = tinymce.settings.JS_BASE_URL + '/'
-    DEFAULT_PATH_TINYMCE = tinymce.settings.JS_ROOT + '/'
-except ImportError:
-    DEFAULT_URL_TINYMCE = settings.STATIC_URL + "grappelli/tinymce/jscripts/tiny_mce/"
-    DEFAULT_PATH_TINYMCE = os.path.join(settings.MEDIA_ROOT, 'admin/tinymce/jscripts/tiny_mce/')
+DEFAULT_URL_TINYMCE = settings.STATIC_URL + "grappelli/tinymce/jscripts/tiny_mce/"
+DEFAULT_PATH_TINYMCE = os.path.join(settings.MEDIA_ROOT, 'admin/tinymce/jscripts/tiny_mce/')
 
 # Set to True in order to see the FileObject when Browsing.
 DEBUG = getattr(settings, "FILEBROWSER_DEBUG", False)


### PR DESCRIPTION
Theses lines have been around since the initial import and I suspect
refer to a dependency or module which no longer exists.