### PR TITLE
Show the old filename in file rename form

### DIFF
--- a/filebrowser_safe/views.py
+++ b/filebrowser_safe/views.py
@@ -476,7 +476,8 @@ def rename(request):
                 (errno, strerror) = xxx_todo_changeme1.args
                 form.errors['name'] = forms.util.ErrorList([_('Error.')])
     else:
-        form = RenameForm(abs_path, file_extension)
+        file_basename = os.path.splitext(filename)[0]
+        form = RenameForm(abs_path, file_extension, initial={'name': file_basename})
 
     return render(request, 'filebrowser/rename.html', {
         'form': form,


### PR DESCRIPTION
Currently, the **"New Name"** form field is empty when trying to rename a file. It would be helpful to have the value set to the old filename.