### PR TITLE
Fixed issue with s3.Bucket object does not support method 'list' any longer

### DIFF
--- a/filebrowser_safe/storage.py
+++ b/filebrowser_safe/storage.py
@@ -82,7 +82,7 @@ class S3BotoStorageMixin(StorageMixin):
             return False
 
         name = self._normalize_name(self._clean_name(name))
-        dirlist = self.bucket.list(self._encode_name(name))
+        dirlist = self.listdir(self._encode_name(name))
 
         # Check whether the iterator is empty
         for item in dirlist:
@@ -112,7 +112,7 @@ class S3BotoStorageMixin(StorageMixin):
 
     def rmtree(self, name):
         name = self._normalize_name(self._clean_name(name))
-        dirlist = self.bucket.list(self._encode_name(name))
+        dirlist = self.listdir(self._encode_name(name))
         for item in dirlist:
             item.delete()
 


### PR DESCRIPTION
This should fix the issue described in https://github.com/stephenmcd/filebrowser-safe/issues/104
This is caused by mismatch of boto version. Django-storages has been updated to use boto3, while filebrowser-safe _assumes_ that the `self.bucket` was created using boto2. The method s3.bucket.list exists only in boto2. 

The fix is to use listdir in **_S3Boto3Storage_**, which in turn is using `self.bucket.objects.filter(Prefix=self._encode_name(name))` to list the content of the bucket

Reference for methods supported in boto3
http://boto3.readthedocs.io/en/latest/reference/services/s3.html?highlight=s3#bucket

Reference for methods supported in boto2
http://boto.cloudhackers.com/en/latest/ref/s3.html#module-boto.s3.bucket