### PR TITLE
modify FOLDER_REGEX to include dotted directory paths

### DIFF
--- a/filebrowser_safe/settings.py
+++ b/filebrowser_safe/settings.py
@@ -96,7 +96,7 @@ DEFAULT_SORTING_BY = getattr(settings, "FILEBROWSER_DEFAULT_SORTING_BY", "date")
 # Sorting Order: asc, desc
 DEFAULT_SORTING_ORDER = getattr(settings, "FILEBROWSER_DEFAULT_SORTING_ORDER", "desc")
 # regex to clean dir names before creation
-FOLDER_REGEX = getattr(settings, "FILEBROWSER_FOLDER_REGEX", r'^[\sa-zA-Z0-9_/-]+$')
+FOLDER_REGEX = getattr(settings, "FILEBROWSER_FOLDER_REGEX", r'^[\sa-zA-Z0-9_/\.-]+$')
 
 # EXTRA TRANSLATION STRINGS
 # The following strings are not availabe within views or templates


### PR DESCRIPTION
Ran into an issue where renaming Media Library files failed on file paths with dotted directory names: e.g. `/var/www/sites/sitename.com/...`.

Propose including `\.` in the default `FOLDER_REGEX` to account for this fairly common naming schema out of the box.