### PR TITLE
Fix import from deprecated `urlresolvers` module

### DIFF
--- a/filebrowser_safe/views.py
+++ b/filebrowser_safe/views.py
@@ -11,7 +11,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.storage import default_storage
 from django.core.files.base import ContentFile
 from django.core.paginator import Paginator, InvalidPage, EmptyPage
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.dispatch import Signal
 from django import forms
 from django.http import HttpResponseRedirect, HttpResponseBadRequest


### PR DESCRIPTION
Importing from the `django.core.urlresolvers` module was deprecated in favor of `django.urls` in Django 1.10, and the former was removed entirely in Django 2.0. Import from `django.urls` instead.