### PR TITLE
Modify the flash_login_required decorator to support custom authentication

### DIFF
--- a/filebrowser_safe/decorators.py
+++ b/filebrowser_safe/decorators.py
@@ -19,7 +19,14 @@ def flash_login_required(function):
             import django.contrib.sessions.backends.db
             engine = django.contrib.sessions.backends.db
         session_data = engine.SessionStore(request.POST.get('session_key'))
-        user_id = session_data['_auth_user_id']
+
+        # Check to see if the request has already set a user (probably from middleware above). If it has,
+        # use the user from the request, as we trust it has been set for a reason
+        if request.user:
+            user_id = request.uer.id
+        else:
+            user_id = session_data['_auth_user_id']
+
         # will return 404 if the session ID does not resolve to a valid user
         request.user = get_object_or_404(get_user_model(), pk=user_id)
         return function(request, *args, **kwargs)

--- a/filebrowser_safe/decorators.py
+++ b/filebrowser_safe/decorators.py
@@ -23,7 +23,7 @@ def flash_login_required(function):
         # Check to see if the request has already set a user (probably from middleware above). If it has,
         # use the user from the request, as we trust it has been set for a reason
         if request.user:
-            user_id = request.uer.id
+            user_id = request.user.id
         else:
             user_id = session_data['_auth_user_id']
 


### PR DESCRIPTION
Currently, the flash_login_required decorator assumes that the user is utilizing Django authentication - attempting to get the user ID from the _auth_user_id session variable.

However, if another authentication scheme is being used, this variable will potentially not be set, and so causes the upload process to throw an exception and fail.

The easiest way around this is to inspect the request.user property and check to see if it has been set - if it has, we assume a middleware above has set it, and we'll use the ID of this user. If not, we fallback to checking the session variable as usual.