### PR TITLE
Use timezone-aware storage API

### DIFF
--- a/filebrowser_safe/base.py
+++ b/filebrowser_safe/base.py
@@ -61,7 +61,7 @@ class FileObjectAPI(object):
     def date(self):
         if self.exists:
             return time.mktime(
-                default_storage.modified_time(self.path).timetuple())
+                default_storage.get_modified_time(self.path).timetuple())
         return None
 
     @property


### PR DESCRIPTION
The non-timezone-aware storage API was deprecated in Django 1.10, and removed in Django 2.0. Use the new timezone-aware API instead.