### PR TITLE
Preserve ACL when when we 'move' a file on S3.

### DIFF
--- a/filebrowser_safe/storage.py
+++ b/filebrowser_safe/storage.py
@@ -100,7 +100,7 @@ class S3BotoStorageMixin(StorageMixin):
         old_key_name = self._encode_name(self._normalize_name(self._clean_name(old_file_name)))
         new_key_name = self._encode_name(self._normalize_name(self._clean_name(new_file_name)))
 
-        k = self.bucket.copy_key(new_key_name, self.bucket.name, old_key_name)
+        k = self.bucket.copy_key(new_key_name, self.bucket.name, old_key_name, preserve_acl=True)
 
         if not k:
             raise "Couldn't copy '%s' to '%s'" % (old_file_name, new_file_name)


### PR DESCRIPTION
## Description

This fixes an issue in `S3BotoStorageMixin` where the `move` method would fail to preserve the existing files ACL policy. This is problematic for S3 buckets that do not default to `public-read` as objects will default to the buckets ACL policy and _not_ the existing objects policy which is expected for a "move" operation.

## Steps to reproduce

1. Create a bucket that doesn't have `public-read` as the buckets default policy
2. Upload a new file
3. Verify correct permissions (as expected)
4. Rename the file
5. Note that the thumbnail is correct, but the image now gets the S3 Access Denied message