### PR TITLE
Fix rmtree method of S3BotoStorageMixin

### DIFF
--- a/filebrowser_safe/storage.py
+++ b/filebrowser_safe/storage.py
@@ -112,9 +112,13 @@ class S3BotoStorageMixin(StorageMixin):
 
     def rmtree(self, name):
         name = self._normalize_name(self._clean_name(name))
-        dirlist = self.listdir(self._encode_name(name))
-        for item in dirlist:
-            item.delete()
+        directories, files = self.listdir(self._encode_name(name))
+
+        for key in files:
+            self.delete('/'.join([name, key]))
+
+        for dirname in directories:
+            self.rmtree('/'.join([name, dirname]))
 
 
 class GoogleStorageMixin(StorageMixin):


### PR DESCRIPTION
The listdir function returns two values, one for directory names and one
for file names. These are lists of strings and thus do not have a delete
method. Instead of trying to delete each array, we loop through them to
build keys that we can delete.