### PR TITLE
Add "renderer" arg to widget render method

### DIFF
--- a/filebrowser_safe/fields.py
+++ b/filebrowser_safe/fields.py
@@ -34,7 +34,7 @@ class FileBrowseWidget(Input):
         else:
             self.attrs = {}
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if value is None:
             value = ""
         directory = self.directory


### PR DESCRIPTION
Support for Widget.render() methods without the renderer argument is removed in django 2.1 (see https://docs.djangoproject.com/en/2.2/releases/2.1/ - last line).

Adding a keyword argument to the signature should't break compatibility with earlier django versions (tested with django 1.11).