### PR TITLE
Allow for absolute path in THUMBNAILS_DIR_NAME setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 *.pyc
 *.eggs/
 *.egg-info
+.idea
 mezzanine-git/

--- a/filebrowser_safe/forms.py
+++ b/filebrowser_safe/forms.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+
+from django.conf import settings
+from django.core.files.storage import default_storage
 from future.builtins import super
 # coding: utf-8
 
@@ -52,6 +55,8 @@ class RenameForm(forms.Form):
 
     def __init__(self, path, file_extension, *args, **kwargs):
         self.path = path
+        if re.match("^https?://", settings.MEDIA_ROOT):
+            self.path = re.sub("^" + settings.MEDIA_ROOT, "", self.path)
         self.file_extension = file_extension
         super(RenameForm, self).__init__(*args, **kwargs)
 
@@ -69,8 +74,8 @@ class RenameForm(forms.Form):
                 not alnum_name_re.search(self.path)):
                 raise forms.ValidationError(_(u'Only letters, numbers, underscores, spaces and hyphens are allowed.'))
             #  folder/file must not already exist.
-            if os.path.isdir(os.path.join(self.path, self.cleaned_data['name'])):
+            if default_storage.isdir(os.path.join(self.path, self.cleaned_data['name'])):
                 raise forms.ValidationError(_(u'The Folder already exists.'))
-            elif os.path.isfile(os.path.join(self.path, self.cleaned_data['name'] + self.file_extension)):
+            elif default_storage.isfile(os.path.join(self.path, self.cleaned_data['name'] + self.file_extension)):
                 raise forms.ValidationError(_(u'The File already exists.'))
         return self.cleaned_data['name']

--- a/filebrowser_safe/locale/cs/LC_MESSAGES/django.po
+++ b/filebrowser_safe/locale/cs/LC_MESSAGES/django.po
@@ -322,7 +322,7 @@ msgstr[1] "%(counter) výsledky"
 #: templates/filebrowser/include/toolbar.html:9
 #, python-format
 msgid "%(full_result_count)s total"
-msgstr "%(full_result_count) celkem"
+msgstr "%(full_result_count)s celkem"
 
 #: templates/filebrowser/include/search.html:5
 msgid "Clear Restrictions"

--- a/filebrowser_safe/storage.py
+++ b/filebrowser_safe/storage.py
@@ -112,9 +112,13 @@ class S3BotoStorageMixin(StorageMixin):
 
     def rmtree(self, name):
         name = self._normalize_name(self._clean_name(name))
-        dirlist = self.listdir(self._encode_name(name))
-        for item in dirlist:
-            item.delete()
+        directories, files = self.listdir(self._encode_name(name))
+
+        for key in files:
+            self.delete('/'.join([name, key]))
+
+        for dirname in directories:
+            self.rmtree('/'.join([name, dirname]))
 
 
 class GoogleStorageMixin(StorageMixin):

--- a/filebrowser_safe/storage.py
+++ b/filebrowser_safe/storage.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 # PYTHON IMPORTS
 import os
 import shutil
+import posixpath
 
 # DJANGO IMPORTS
 from django.core.files.move import file_move_safe
@@ -133,7 +134,7 @@ class GoogleStorageMixin(StorageMixin):
             return False
 
         name = self._normalize_name(self._clean_name(name))
-        dirlist = self.bucket.list(self._encode_name(name))
+        dirlist = self.listdir(self._encode_name(name))
 
         # Check whether the iterator is empty
         for item in dirlist:
@@ -163,6 +164,32 @@ class GoogleStorageMixin(StorageMixin):
 
     def rmtree(self, name):
         name = self._normalize_name(self._clean_name(name))
-        dirlist = self.bucket.list(self._encode_name(name))
+        dirlist = self.listdir(self._encode_name(name))
         for item in dirlist:
             item.delete()
+
+    def _clean_name(self, name):
+        """
+        Cleans the name so that Windows style paths work
+        """
+        return clean_name(name)
+
+
+def clean_name(name):
+    """
+    Cleans the name so that Windows style paths work
+    """
+    # Normalize Windows style paths
+    clean_name = posixpath.normpath(name).replace('\\', '/')
+
+    # os.path.normpath() can strip trailing slashes so we implement
+    # a workaround here.
+    if name.endswith('/') and not clean_name.endswith('/'):
+        # Add a trailing slash as it was stripped.
+        clean_name = clean_name + '/'
+
+    # Given an empty string, os.path.normpath() will return ., which we don't want
+    if clean_name == '.':
+        clean_name = ''
+
+    return clean_name

--- a/filebrowser_safe/views.py
+++ b/filebrowser_safe/views.py
@@ -72,7 +72,11 @@ def remove_thumbnails(file_path):
     """
     from mezzanine.conf import settings
     dir_name, file_name = os.path.split(file_path)
-    path = os.path.join(dir_name, settings.THUMBNAILS_DIR_NAME, file_name)
+    if os.path.isabs(settings.THUMBNAILS_DIR_NAME):
+        path = os.path.join(settings.THUMBNAILS_DIR_NAME, dir_name, file_name)
+    else:
+        path = os.path.join(dir_name, settings.THUMBNAILS_DIR_NAME, file_name)
+
     try:
         default_storage.rmtree(path)
     except:


### PR DESCRIPTION
This PR corresponds to this PR in mezzanine: https://github.com/stephenmcd/mezzanine/pull/1952

Allows for the use of an absolute path in THUMBNAILS_DIR_NAME.

Additionally, uses `default_storage` for file operations rather than `os`, so that file renames will work when using remote storage.