### PR TITLE
filebowser-safe Django 2.2 compatability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,17 @@
 language: python
 python:
-  - "3.6"
   - "3.5"
+  - "3.8"
 env:
   - DJANGO="master"
-  - DJANGO="21"
-  - DJANGO="20"
-  - DJANGO="111"
+  - DJANGO="22"
 matrix:
   fast_finish: true
   include:
-    - python: "3.4"
-      env: DJANGO="111"
-    - python: "2.7"
-      env: DJANGO="111"
+    - python: "3.5"
+      env: DJANGO="22"
+    - python: "3.8"
+      env: DJANGO="22"
   allow_failures:
     - env: DJANGO="master"
 install:

--- a/filebrowser_safe/base.py
+++ b/filebrowser_safe/base.py
@@ -31,17 +31,17 @@ class FileObjectAPI(object):
         self.mimetype = mimetypes.guess_type(self.filename)
 
     def __str__(self):
-        return smart_str(self.path)
+        return smart_str(self.name)
 
     def __unicode__(self):
-        return smart_text(self.path)
+        return smart_text(self.name)
 
     def __repr__(self):
         return smart_str("<%s: %s>" % (
             self.__class__.__name__, self or "None"))
 
     def __len__(self):
-        return len(self.path)
+        return len(self.name)
 
     # GENERAL ATTRIBUTES
 
@@ -54,7 +54,7 @@ class FileObjectAPI(object):
     @cached_property
     def filesize(self):
         if self.exists:
-            return default_storage.size(self.path)
+            return default_storage.size(self.name)
         return None
 
     @cached_property
@@ -72,20 +72,20 @@ class FileObjectAPI(object):
 
     @cached_property
     def exists(self):
-        return default_storage.exists(self.path)
+        return default_storage.exists(self.name)
 
     # PATH/URL ATTRIBUTES
 
     @property
     def path_relative_directory(self):
         """ path relative to the path returned by get_directory() """
-        return path_strip(self.path, get_directory()).lstrip("/")
+        return path_strip(self.name, get_directory()).lstrip("/")
 
     # FOLDER ATTRIBUTES
 
     @property
     def directory(self):
-        return path_strip(self.path, get_directory())
+        return path_strip(self.name, get_directory())
 
     @property
     def folder(self):
@@ -100,7 +100,7 @@ class FileObjectAPI(object):
     def is_empty(self):
         if self.is_folder:
             try:
-                dirs, files = default_storage.listdir(self.path)
+                dirs, files = default_storage.listdir(self.name)
             except UnicodeDecodeError:
                 from mezzanine.core.exceptions import FileSystemEncodingChanged
                 raise FileSystemEncodingChanged()
@@ -131,7 +131,7 @@ class FileObject(FileObjectAPI):
 
     @property
     def url(self):
-        return default_storage.url(self.path)
+        return default_storage.url(self.name)
 
 
 class FieldFileObject(FieldFile, FileObjectAPI):
@@ -148,7 +148,7 @@ class FieldFileObject(FieldFile, FileObjectAPI):
 
     def delete(self, **kwargs):
         if self.is_folder:
-            default_storage.rmtree(self.path)
+            default_storage.rmtree(self.name)
         else:
             super(FieldFileObject, self).delete(**kwargs)
 

--- a/filebrowser_safe/fields.py
+++ b/filebrowser_safe/fields.py
@@ -12,6 +12,7 @@ from django.db.models.fields.files import FileDescriptor
 from django.forms.widgets import Input
 from django.template.loader import render_to_string
 from django.utils.encoding import smart_str
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
 from filebrowser_safe.settings import *
@@ -34,7 +35,7 @@ class FileBrowseWidget(Input):
         else:
             self.attrs = {}
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if value is None:
             value = ""
         directory = self.directory
@@ -51,7 +52,10 @@ class FileBrowseWidget(Input):
         final_attrs['extensions'] = self.extensions
         final_attrs['format'] = self.format
         final_attrs['DEBUG'] = DEBUG
-        return render_to_string("filebrowser/custom_field.html", dict(locals(), MEDIA_URL=MEDIA_URL))
+        if renderer is not None:
+            return mark_safe(renderer.render("filebrowser/custom_field.html", dict(locals(), MEDIA_URL=MEDIA_URL)))
+        else:
+            return render_to_string("filebrowser/custom_field.html", dict(locals(), MEDIA_URL=MEDIA_URL))
 
 
 class FileBrowseFormField(forms.CharField):

--- a/filebrowser_safe/fields.py
+++ b/filebrowser_safe/fields.py
@@ -24,7 +24,10 @@ class FileBrowseWidget(Input):
     input_type = 'text'
 
     class Media:
-        js = (os.path.join(URL_FILEBROWSER_MEDIA, 'js/AddFileBrowser.js'), )
+        js = (
+            'admin/js/jquery.init.js',
+            os.path.join(URL_FILEBROWSER_MEDIA, 'js/AddFileBrowser.js'),
+        )
 
     def __init__(self, attrs=None):
         self.directory = attrs.get('directory', '')

--- a/filebrowser_safe/forms.py
+++ b/filebrowser_safe/forms.py
@@ -1,17 +1,17 @@
 from __future__ import unicode_literals
-from future.builtins import super
-# coding: utf-8
 
 # imports
 import os
 import re
-
 # django imports
 from django import forms
 from django.utils.translation import ugettext as _
+from future.builtins import super
 
 # filebrowser imports
 from filebrowser_safe.settings import FOLDER_REGEX
+
+# coding: utf-8
 
 
 alnum_name_re = re.compile(FOLDER_REGEX)

--- a/filebrowser_safe/static/filebrowser/css/filebrowser.css
+++ b/filebrowser_safe/static/filebrowser/css/filebrowser.css
@@ -3,6 +3,7 @@
 .filebrowser thead th.sorted a { padding-right: 13px; }
 .filebrowser td { padding: 9px 10px 7px 10px !important; }
 .filebrowser td.fb_icon { padding: 6px 5px 5px 5px !important; }
+.filebrowser td.fb_icon img { max-width: 100px; }
 
 table a.fb_deletelink, table a.fb_renamelink, table a.fb_selectlink, table a.fb_showversionslink {
     cursor: pointer;

--- a/filebrowser_safe/views.py
+++ b/filebrowser_safe/views.py
@@ -127,7 +127,9 @@ def browse(request):
 
         # FILTER / SEARCH
         append = False
-        if fileobject.filetype == request.GET.get('filter_type', fileobject.filetype) and get_filterdate(request.GET.get('filter_date', ''), fileobject.date):
+        if fileobject.filetype == request.GET.get('filter_type', fileobject.filetype) and fileobject.filetype == "Folder":
+            append = True
+        elif fileobject.filetype == request.GET.get('filter_type', fileobject.filetype) and get_filterdate(request.GET.get('filter_date', ''), fileobject.date):
             append = True
         if request.GET.get('q') and not re.compile(request.GET.get('q').lower(), re.M).search(file.lower()):
             append = False

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,11 @@
 [tox]
 envlist =
-    py{36,35}-dj{master,21,20,111}
-    py{34,27}-dj111
+    py{38,35}-dj{master,22}
 
 [testenv]
 commands = python setup.py test
 
 deps =
     djmaster: git+https://github.com/django/django.git@master#egg=Django
-    dj21: Django>=2.1,<2.2
-    dj20: Django>=2.0,<2.1
-    dj111: Django>=1.11,<2.0
-    dj{master,21,20}: git+https://github.com/stephenmcd/mezzanine.git@master#egg=mezzanine
+    dj22: Django>=2.2,<2.3
+    dj{master,22}: git+https://github.com/fermorltd/mezzanine.git@2.2-compat#egg=mezzanine


### PR DESCRIPTION
When combined with the [2.2 Compatibility PR for Mezzanine ](https://github.com/stephenmcd/mezzanine/pull/1956) this PR makes filebrowser_safe compatible with Django 2.2