### PR TITLE
Django 4.0.0 compatibility, fixes #135

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,12 +53,12 @@ jobs:
           - tox-env: "py310-dj32"
             python-version: "3.10"
           # Django 4.0
-          # - tox-env: "py38-dj40"
-          #   python-version: "3.8"
-          # - tox-env: "py39-dj40"
-          #   python-version: "3.9"
-          # - tox-env: "py310-dj40"
-          #   python-version: "3.10"
+          - tox-env: "py38-dj40"
+            python-version: "3.8"
+          - tox-env: "py39-dj40"
+            python-version: "3.9"
+          - tox-env: "py310-dj40"
+            python-version: "3.10"
 
     steps:
       - uses: actions/checkout@v2

--- a/filebrowser_safe/base.py
+++ b/filebrowser_safe/base.py
@@ -9,11 +9,7 @@ from django.db.models.fields.files import FieldFile
 from django.utils.encoding import smart_str
 from django.utils.functional import cached_property
 
-try:
-    from django.utils.encoding import smart_text
-except ImportError:
-    # Backward compatibility for Py2 and Django < 1.5
-    from django.utils.encoding import smart_unicode as smart_text
+from django.utils.encoding import smart_str
 
 from filebrowser_safe.functions import get_directory, get_file_type, path_strip
 
@@ -32,7 +28,7 @@ class FileObjectAPI:
         return smart_str(self.name)
 
     def __unicode__(self):
-        return smart_text(self.name)
+        return smart_str(self.name)
 
     def __repr__(self):
         return smart_str("<{}: {}>".format(self.__class__.__name__, self or "None"))

--- a/filebrowser_safe/base.py
+++ b/filebrowser_safe/base.py
@@ -9,13 +9,11 @@ from django.db.models.fields.files import FieldFile
 from django.utils.encoding import smart_str
 from django.utils.functional import cached_property
 
-from django.utils.encoding import smart_str
-
 from filebrowser_safe.functions import get_directory, get_file_type, path_strip
 
 
 class FileObjectAPI:
-    """ A mixin class providing file properties. """
+    """A mixin class providing file properties."""
 
     def __init__(self, path):
         self.head = os.path.dirname(path)
@@ -70,7 +68,7 @@ class FileObjectAPI:
 
     @property
     def path_relative_directory(self):
-        """ path relative to the path returned by get_directory() """
+        """path relative to the path returned by get_directory()"""
         return path_strip(self.name, get_directory()).lstrip("/")
 
     # FOLDER ATTRIBUTES

--- a/filebrowser_safe/templates/filebrowser/custom_field.html
+++ b/filebrowser_safe/templates/filebrowser/custom_field.html
@@ -15,7 +15,7 @@
   );">
     <img src="{{ final_attrs.search_icon }}" alt="" />
 </a>
-{% ifequal value.filetype "Image" %}
+{% if value.filetype == "Image" %}
 <p class="help mezz-fb-thumbnail" id="help_{{ final_attrs.id }}">
     <a href="{{ value.url }}" target="_blank" id="link_{{ final_attrs.id }}">
         <img id="image_{{ final_attrs.id }}" src="{{ MEDIA_URL }}{% thumbnail value.name 60 60 %}" class="preview" />
@@ -28,7 +28,7 @@
     </a>
     {{ value.path }}
 </p>
-{% endifequal %}
+{% endif %}
 {% if not self.is_required %}
     <p class="help mezz-fb-clear" id="clear_{{ final_attrs.id }}" style="display:{% if value %}inline{% else %}none{% endif %}; margin:0 10px;">
         <a href="javascript:FileBrowser.clear('{{ final_attrs.id }}');">{% trans "Clear" %}</a>

--- a/filebrowser_safe/templates/filebrowser/include/filelisting.html
+++ b/filebrowser_safe/templates/filebrowser/include/filelisting.html
@@ -10,18 +10,18 @@ h1 {margin:-30px 0 15px 0;}
 <tr class="{% cycle 'row1' 'row2' %}">
 
     <!-- FILESELECT FOR FILEBROWSEFIELD -->
-    {% ifequal query.pop '1' %}
+    {% if query.pop == '1' %}
     {% if results_var.select_total %}
     <td class="fb_icon">
         {% selectable file.filetype query.type %}
         {% if selectable %}
-        <a href="javascript://" onclick="FileSubmit('{{ file.path }}', '{{ file.url }}', '{{ settings_var.MEDIA_URL }}{% ifequal file.filetype 'Image' %}{% thumbnail file.path 60 60 %}{% else %}{{ file.path }}{% endifequal %}', '{{ file.filetype }}');" class="fb_selectlink" title="{% trans 'Select' %}"></a>
+        <a href="javascript://" onclick="FileSubmit('{{ file.path }}', '{{ file.url }}', '{{ settings_var.MEDIA_URL }}{% if file.filetype == 'Image' %}{% thumbnail file.path 60 60 %}{% else %}{{ file.path }}{% endif %}', '{{ file.filetype }}');" class="fb_selectlink" title="{% trans 'Select' %}"></a>
         {% else %}
         <img src="{{ settings_var.URL_FILEBROWSER_MEDIA }}img/filebrowser_icon_select_disabled.gif" width="23" height="17" />
         {% endif %}
     </td>
     {% endif %}
-    {% endifequal %}
+    {% endif %}
 
     <!-- FILESELECT FOR RTE/TINYMCE -->
     {% if query.pop == '2' or query.pop == '5' %}
@@ -38,7 +38,7 @@ h1 {margin:-30px 0 15px 0;}
     {% endif %}
 
     <!-- FILESELECT FOR CKEDITOR (FORMER "FCKEDITOR") -->
-    {% ifequal query.pop '3' %}
+    {% if query.pop == '3' %}
     {% if results_var.select_total %}
     <td class="fb_icon">
         {% selectable file.filetype query.type %}
@@ -49,10 +49,10 @@ h1 {margin:-30px 0 15px 0;}
         {% endif %}
     </td>
     {% endif %}
-    {% endifequal %}
+    {% endif %}
 
     <!-- GENERIC FILESELECT: opener grabs file url from rel attribute dynamically on click -->
-    {% ifequal query.pop '4' %}
+    {% if query.pop == '4' %}
     {% if results_var.select_total %}
     <td class="fb_icon">
         {% selectable file.filetype query.type %}
@@ -63,7 +63,7 @@ h1 {margin:-30px 0 15px 0;}
         {% endif %}
     </td>
     {% endif %}
-    {% endifequal %}
+    {% endif %}
 
     <!-- FILEICON -->
     <td class="fb_icon"><img src="{{ settings_var.URL_FILEBROWSER_MEDIA }}img/filebrowser_type_{{ file.filetype|lower }}.gif" /></td>
@@ -71,18 +71,18 @@ h1 {margin:-30px 0 15px 0;}
     <!-- THUMBNAIL -->
     {% if results_var.images_total %}
     <td class="fb_icon">
-        {% ifequal file.filetype 'Image' %}
+        {% if file.filetype == 'Image' %}
         <a href="{{ file.url }}" target="_blank"><img src="{{ settings_var.MEDIA_URL }}{% thumbnail file.path 60 60 %}" title="{% trans 'View Image' %}" /></a>
-        {% endifequal %}
+        {% endif %}
     </td>
     {% endif %}
 
     <!-- FILENAME/DIMENSIONS -->
-    {% ifequal file.filetype 'Folder' %}
+    {% if file.filetype == 'Folder' %}
     <td><b><a href="{% url "fb_browse" %}{% query_string "" "q,dir,p" %}&amp;dir={{ file.path_relative_directory|urlencode }}">{{ file.filename }}</a></b></td>
     {% else %}
     <td><b><a href="{{ file.url }}" target="_blank">{{ file.filename }}</a></b></td>
-    {% endifequal %}
+    {% endif %}
 
     <!-- RENAME -->
     {% if query.pop != '4' %}
@@ -97,13 +97,13 @@ h1 {margin:-30px 0 15px 0;}
 
     <!-- DELETE -->
     <td class="fb_icon">
-        {% ifnotequal file.filetype 'Folder' %}
+        {% if file.filetype != 'Folder' %}
         <form method="POST" action="{% url "fb_delete" %}{% query_string %}&amp;filename={{ file.filename }}&amp;filetype={{ file.filetype }}" id="delete-{{ forloop.counter0 }}">{% csrf_token %}</form>
         <a href="#" class="fb_deletelink" onclick="if (confirm('{% trans "Are you sure you want to delete this file?" %}')) {jQuery('#delete-{{ forloop.counter0 }}').submit();} return false;" title="{% trans 'Delete File' %}"></a>
         {% else %}
         <form method="POST" action="{% url "fb_delete" %}{% query_string %}&amp;filename={{ file.filename }}&amp;filetype={{ file.filetype }}" id="delete-{{ forloop.counter0 }}">{% csrf_token %}</form>
         <a href="#" class="fb_deletelink" onclick="if (confirm('{% trans "Are you sure you want to delete this Folder?" %}')) {jQuery('#delete-{{ forloop.counter0 }}').submit();} return false;" title="{% trans 'Delete Folder' %}"></a>
-        {% endifnotequal %}
+        {% endif %}
     </td>
 
     <!-- DEBUG -->
@@ -121,15 +121,15 @@ h1 {margin:-30px 0 15px 0;}
         <strong>Full URL</strong> {{ file.url }}<br /><br />
         <strong>URL for FileBrowseField</strong> {{ file.url }}<br />
         <strong>Thumbnail URL</strong> {{ file.url_thumbnail }}
-        {% ifequal file.filetype 'Image' %}<br /><br />
+        {% if file.filetype == 'Image' %}<br /><br />
         <strong>Dimensions</strong> {{ file.dimensions }}<br />
         <strong>Width</strong> {{ file.width }}<br />
         <strong>Height</strong> {{ file.height }}<br />
         <strong>Orientation</strong> {{ file.orientation }}
-        {% endifequal %}
-        {% ifequal file.filetype 'Folder' %}<br /><br />
+        {% endif %}
+        {% if file.filetype == 'Folder' %}<br /><br />
         <strong>Is Empty</strong> {{ file.is_empty }}
-        {% endifequal %}
+        {% endif %}
     </td>
     {% endif %}
 

--- a/filebrowser_safe/templates/filebrowser/include/filter.html
+++ b/filebrowser_safe/templates/filebrowser/include/filter.html
@@ -9,13 +9,13 @@
 <h3 class="form-row">{% trans "By Date" %}</h3>
 <ul>
      {% if query.filter_date %}<li class="form-row narrow">{% else %}<li class="form-row narrow selected">{% endif %}<a href="{% query_string "" "filter_date,p" %}">{% trans "Any Date" %}</a></li>
-     {% ifequal query.filter_date 'today' %}<li class="form-row narrow selected">{% else %}<li class="form-row narrow">{% endifequal %}
+     {% if query.filter_date == 'today' %}<li class="form-row narrow selected">{% else %}<li class="form-row narrow">{% endif %}
      <a href="{% query_string "" "filter_date,p" %}&amp;filter_date=today">{% trans "Today" %}</a></li>
-     {% ifequal query.filter_date 'past7days' %}<li class="form-row narrow selected">{% else %}<li class="form-row narrow">{% endifequal %}
+     {% if query.filter_date == 'past7days' %}<li class="form-row narrow selected">{% else %}<li class="form-row narrow">{% endif %}
      <a href="{% query_string "" "filter_date,p" %}&amp;filter_date=past7days">{% trans "Past 7 days" %}</a></li>
-     {% ifequal query.filter_date 'thismonth' %}<li class="form-row narrow selected">{% else %}<li class="form-row narrow">{% endifequal %}
+     {% if query.filter_date == 'thismonth' %}<li class="form-row narrow selected">{% else %}<li class="form-row narrow">{% endif %}
      <a href="{% query_string "" "filter_date,p" %}&amp;filter_date=thismonth">{% trans "Past 30 days" %}</a></li>
-     {% ifequal query.filter_date 'thisyear' %}<li class="form-row narrow selected">{% else %}<li class="form-row narrow">{% endifequal %}
+     {% if query.filter_date == 'thisyear' %}<li class="form-row narrow selected">{% else %}<li class="form-row narrow">{% endif %}
      <a href="{% query_string "" "filter_date,p" %}&amp;filter_date=thisyear">{% trans "This year" %}</a></li>
 </ul>
 </div>
@@ -28,7 +28,7 @@
 <ul>
     {% if query.filter_type %}<li class="form-row narrow">{% else %}<li class="form-row narrow selected">{% endif %}<a href="{% query_string "" "filter_type,p" %}">{% trans "All" %}</a></li>
     {% for extension in settings_var.EXTENSIONS %}
-    {% ifequal query.filter_type extension %}<li class="form-row narrow selected">{% else %}<li class="form-row narrow">{% endifequal %}<a href="{% query_string "" "filter_type,p" %}&amp;filter_type={{ extension }}">{% trans extension %}</a></li>
+    {% if query.filter_type == extension %}<li class="form-row narrow selected">{% else %}<li class="form-row narrow">{% endif %}<a href="{% query_string "" "filter_type,p" %}&amp;filter_type={{ extension }}">{% trans extension %}</a></li>
     {% endfor %}
 </ul>
 </div>

--- a/filebrowser_safe/templates/filebrowser/include/paginator.html
+++ b/filebrowser_safe/templates/filebrowser/include/paginator.html
@@ -11,15 +11,15 @@
     <strong>{% blocktrans count results_var.results_total as counter %}{{ counter }} Item{% plural %}{{ counter }} Items{% endblocktrans %}</strong>&nbsp;
     {% if page_range %}
         {% for i in page_range %}
-            {% ifequal i "." %}
+            {% if i == "." %}
                 ...
             {% else %}
-                {% ifequal i page_num %}
+                {% if i == page_num %}
                     <span class="this-page">{{ i|add:"1" }}</span>
                 {% else %}
                     <a href="{% query_string '' 'p' %}&amp;p={{ i|add:"1" }}">{{ i|add:"1" }}</a>
-                {% endifequal %}
-            {% endifequal %}
+                {% endif %}
+            {% endif %}
         {% endfor %}
     {% endif %}
 {% else %}

--- a/filebrowser_safe/templates/filebrowser/include/tableheader.html
+++ b/filebrowser_safe/templates/filebrowser/include/tableheader.html
@@ -2,29 +2,29 @@
 <thead>
     <tr>
     <!-- SELECT -->
-    {% ifequal query.pop '1' %}{% if results_var.select_total %}<th></th>{% endif %}{% endifequal %}
-    {% ifequal query.pop '2' %}{% if results_var.select_total %}<th></th>{% endif %}{% endifequal %}
-    {% ifequal query.pop '3' %}{% if results_var.select_total %}<th></th>{% endif %}{% endifequal %}
-    {% ifequal query.pop '4' %}{% if results_var.select_total %}<th></th>{% endif %}{% endifequal %}
-    {% ifequal query.pop '5' %}{% if results_var.select_total %}<th></th>{% endif %}{% endifequal %}
+    {% if query.pop == '1' %}{% if results_var.select_total %}<th></th>{% endif %}{% endif %}
+    {% if query.pop == '2' %}{% if results_var.select_total %}<th></th>{% endif %}{% endif %}
+    {% if query.pop == '3' %}{% if results_var.select_total %}<th></th>{% endif %}{% endif %}
+    {% if query.pop == '4' %}{% if results_var.select_total %}<th></th>{% endif %}{% endif %}
+    {% if query.pop == '5' %}{% if results_var.select_total %}<th></th>{% endif %}{% endif %}
     <!-- FILETYPE -->
-    {% ifequal query.o 'filetype' %}<th class="sorted {{ query.ot }}ending"><a href="{% query_string "" "o,ot,p" %}&amp;ot={% ifequal query.ot 'desc' %}asc{% else %}desc{% endifequal %}&amp;o=filetype"></a></th>{% endifequal %}
-    {% ifnotequal query.o 'filetype' %}<th><a href="{% query_string "" "o,ot,p" %}&amp;ot=asc&amp;o=filetype">&nbsp;</a></th>{% endifnotequal %}
+    {% if query.o == 'filetype' %}<th class="sorted {{ query.ot }}ending"><a href="{% query_string "" "o,ot,p" %}&amp;ot={% if query.ot == 'desc' %}asc{% else %}desc{% endif %}&amp;o=filetype"></a></th>{% endif %}
+    {% if query.o != 'filetype' %}<th><a href="{% query_string "" "o,ot,p" %}&amp;ot=asc&amp;o=filetype">&nbsp;</a></th>{% endif %}
     <!-- THUMB -->
     {% if results_var.images_total %}<th>&nbsp;</th>{% endif %}
     <!-- FILENAME / DIMENSIONS  -->
-    {% ifequal query.o 'filename_lower' %}<th class="sorted {{ query.ot }}ending"><a href="{% query_string "" "o,ot,p" %}&amp;ot={% ifequal query.ot 'desc' %}asc{% else %}desc{% endifequal %}&amp;o=filename_lower">{% trans 'Filename' %}</a></th>{% endifequal %}
-    {% ifnotequal query.o 'filename_lower' %}<th><a href="{% query_string "" "o,ot,p" %}&amp;ot=asc&amp;o=filename_lower">{% trans 'Filename' %}</a></th>{% endifnotequal %}
+    {% if query.o == 'filename_lower' %}<th class="sorted {{ query.ot }}ending"><a href="{% query_string "" "o,ot,p" %}&amp;ot={% if query.ot == 'desc' %}asc{% else %}desc{% endif %}&amp;o=filename_lower">{% trans 'Filename' %}</a></th>{% endif %}
+    {% if query.o != 'filename_lower' %}<th><a href="{% query_string "" "o,ot,p" %}&amp;ot=asc&amp;o=filename_lower">{% trans 'Filename' %}</a></th>{% endif %}
     <!-- RENAME -->
     {% if query.pop != '4' %}
     <th>&nbsp;</th>
     {% endif %}
     <!-- SIZE -->
-    {% ifequal query.o 'filesize' %}<th class="sorted {{ query.ot }}ending"><a href="{% query_string "" "o,ot,p" %}&amp;ot={% ifequal query.ot 'desc' %}asc{% else %}desc{% endifequal %}&amp;o=filesize">{% trans 'Size' %}</a></th>{% endifequal %}
-    {% ifnotequal query.o 'filesize' %}<th><a href="{% query_string "" "o,ot,p" %}&amp;ot=asc&amp;o=filesize">{% trans 'Size' %}</a></th>{% endifnotequal %}
+    {% if query.o == 'filesize' %}<th class="sorted {{ query.ot }}ending"><a href="{% query_string "" "o,ot,p" %}&amp;ot={% if query.ot == 'desc' %}asc{% else %}desc{% endif %}&amp;o=filesize">{% trans 'Size' %}</a></th>{% endif %}
+    {% if query.o != 'filesize' %}<th><a href="{% query_string "" "o,ot,p" %}&amp;ot=asc&amp;o=filesize">{% trans 'Size' %}</a></th>{% endif %}
     <!-- DATE -->
-    {% ifequal query.o 'date' %}<th class="sorted {{ query.ot }}ending"><a href="{% query_string "" "o,ot,p" %}&amp;ot={% ifequal query.ot 'desc' %}asc{% else %}desc{% endifequal %}&amp;o=date">{% trans 'Date' %}</a></th>{% endifequal %}
-    {% ifnotequal query.o 'date' %}<th><a href="{% query_string "" "o,ot,p" %}&amp;ot=asc&amp;o=date">{% trans 'Date' %}</a></th>{% endifnotequal %}
+    {% if query.o == 'date' %}<th class="sorted {{ query.ot }}ending"><a href="{% query_string "" "o,ot,p" %}&amp;ot={% if query.ot == 'desc' %}asc{% else %}desc{% endif %}&amp;o=date">{% trans 'Date' %}</a></th>{% endif %}
+    {% if query.o != 'date' %}<th><a href="{% query_string "" "o,ot,p" %}&amp;ot=asc&amp;o=date">{% trans 'Date' %}</a></th>{% endif %}
     <!-- DELETE -->
     <th>&nbsp;</th>
     {% if settings_var.DEBUG %}<th>Debug</th>{% endif %}

--- a/filebrowser_safe/templates/filebrowser/index.html
+++ b/filebrowser_safe/templates/filebrowser/index.html
@@ -14,23 +14,23 @@
 {% block extrahead %}
 {{ block.super }}
 
-{% ifequal query.pop '1' %} <!-- FileBrowseField -->
+{% if query.pop == '1' %} <!-- FileBrowseField -->
 <script language="javascript" type="text/javascript" src="{{ settings_var.URL_FILEBROWSER_MEDIA }}js/FB_FileBrowseField.js"></script>
-{% endifequal %}
+{% endif %}
 
-{% ifequal query.pop '2' %} <!-- TinyMCE < 4 -->
+{% if query.pop == '2' %} <!-- TinyMCE < 4 -->
 <script language="javascript" type="text/javascript" src="{{ settings_var.URL_TINYMCE }}tiny_mce_popup.js"></script>
 <script language="javascript" type="text/javascript" src="{{ settings_var.URL_FILEBROWSER_MEDIA }}js/FB_TinyMCE.js"></script>
 {% if query.mce_rdomain %}<script language="javascript">document.domain = "{{ query.mce_rdomain }}"</script>{% endif %}
-{% endifequal %}
+{% endif %}
 
-{% ifequal query.pop '3' %} <!-- CKeditor (former "FCKeditor") -->
+{% if query.pop == '3' %} <!-- CKeditor (former "FCKeditor") -->
 <script language="javascript" type="text/javascript" src="{{ settings_var.URL_FILEBROWSER_MEDIA }}js/FB_CKEditor.js"></script>
-{% endifequal %}
+{% endif %}
 
-{% ifequal query.pop '5' %} <!-- TinyMCE 4 -->
+{% if query.pop == '5' %} <!-- TinyMCE 4 -->
 <script language="javascript" type="text/javascript" src="{{ settings_var.URL_FILEBROWSER_MEDIA }}js/FB_TinyMCE4.js"></script>
-{% endifequal %}
+{% endif %}
 
 <script type="text/javascript" src="{% static "grappelli/js/admin/Changelist.js" %}"></script>
 

--- a/filebrowser_safe/templatetags/fb_tags.py
+++ b/filebrowser_safe/templatetags/fb_tags.py
@@ -1,7 +1,8 @@
 import warnings
 
 from django import template
-from django.utils.http import urlquote
+
+from urllib.parse import quote
 
 from filebrowser_safe.settings import EXTENSIONS, SELECT_FORMATS
 
@@ -82,7 +83,7 @@ def get_query_string(p, new_params=None, remove=None):
             del p[k]
         elif v is not None:
             p[k] = v
-    return "?" + "&".join(f"{urlquote(k)}={urlquote(v)}" for k, v in p.items())
+    return "?" + "&".join(f"{quote(k)}={quote(v)}" for k, v in p.items())
 
 
 def string_to_dict(string):

--- a/filebrowser_safe/urls.py
+++ b/filebrowser_safe/urls.py
@@ -1,13 +1,13 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from filebrowser_safe import views
 
 urlpatterns = [
-    url(r"^browse/$", views.browse, name="fb_browse"),
-    url(r"^mkdir/", views.mkdir, name="fb_mkdir"),
-    url(r"^upload/", views.upload, name="fb_upload"),
-    url(r"^rename/$", views.rename, name="fb_rename"),
-    url(r"^delete/$", views.delete, name="fb_delete"),
-    url(r"^check_file/$", views._check_file, name="fb_check"),
-    url(r"^upload_file/$", views._upload_file, name="fb_do_upload"),
+    re_path(r"^browse/$", views.browse, name="fb_browse"),
+    re_path(r"^mkdir/", views.mkdir, name="fb_mkdir"),
+    re_path(r"^upload/", views.upload, name="fb_upload"),
+    re_path(r"^rename/$", views.rename, name="fb_rename"),
+    re_path(r"^delete/$", views.delete, name="fb_delete"),
+    re_path(r"^check_file/$", views._check_file, name="fb_check"),
+    re_path(r"^upload_file/$", views._upload_file, name="fb_do_upload"),
 ]

--- a/filebrowser_safe/views.py
+++ b/filebrowser_safe/views.py
@@ -19,11 +19,7 @@ from django.views.decorators.cache import never_cache
 from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.decorators.csrf import csrf_exempt
 
-try:
-    from django.utils.encoding import smart_text
-except ImportError:
-    # Backward compatibility for Py2 and Django < 1.5
-    from django.utils.encoding import smart_unicode as smart_text
+from django.utils.encoding import smart_str
 
 from django.utils.module_loading import import_string
 
@@ -230,8 +226,8 @@ browse = staff_member_required(never_cache(browse))
 
 
 # mkdir signals
-filebrowser_pre_createdir = Signal(providing_args=["path", "dirname"])
-filebrowser_post_createdir = Signal(providing_args=["path", "dirname"])
+filebrowser_pre_createdir = Signal()
+filebrowser_post_createdir = Signal()
 
 
 @xframe_options_sameorigin
@@ -364,8 +360,8 @@ def _check_file(request):
 
 
 # upload signals
-filebrowser_pre_upload = Signal(providing_args=["path", "file"])
-filebrowser_post_upload = Signal(providing_args=["path", "file"])
+filebrowser_pre_upload = Signal()
+filebrowser_post_upload = Signal()
 
 
 @csrf_exempt
@@ -412,8 +408,8 @@ def _upload_file(request):
             uploadedfile = default_storage.save(file_path, filedata)
             if default_storage.exists(file_path) and file_path != uploadedfile:
                 default_storage.move(
-                    smart_text(uploadedfile),
-                    smart_text(file_path),
+                    smart_str(uploadedfile),
+                    smart_str(file_path),
                     allow_overwrite=True,
                 )
 
@@ -421,7 +417,7 @@ def _upload_file(request):
             filebrowser_post_upload.send(
                 sender=request,
                 path=request.POST.get("folder"),
-                file=FileObject(smart_text(file_path)),
+                file=FileObject(smart_str(file_path)),
             )
         get_params = request.POST.get("get_params")
         if get_params:
@@ -430,8 +426,8 @@ def _upload_file(request):
 
 
 # delete signals
-filebrowser_pre_delete = Signal(providing_args=["path", "filename"])
-filebrowser_post_delete = Signal(providing_args=["path", "filename"])
+filebrowser_pre_delete = Signal()
+filebrowser_post_delete = Signal()
 
 
 @xframe_options_sameorigin
@@ -499,8 +495,8 @@ delete = staff_member_required(never_cache(delete))
 
 
 # rename signals
-filebrowser_pre_rename = Signal(providing_args=["path", "filename", "new_filename"])
-filebrowser_post_rename = Signal(providing_args=["path", "filename", "new_filename"])
+filebrowser_pre_rename = Signal()
+filebrowser_post_rename = Signal()
 
 
 @xframe_options_sameorigin

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,9 +1,10 @@
-from django.conf.urls import include, url
+from django.conf.urls import include
+from django.urls import re_path
 from django.contrib import admin
 
 admin.autodiscover()
 
 urlpatterns = [
-    url(r"^admin/filebrowser/", include("filebrowser_safe.urls")),
-    url(r"^admin/", admin.site.urls),
+    re_path(r"^admin/filebrowser/", include("filebrowser_safe.urls")),
+    re_path(r"^admin/", admin.site.urls),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39,310}-dj{22,30,31,32}
+    py{36,37,38,39,310}-dj{22,30,31,32,40}
     package
     lint
 
@@ -13,6 +13,7 @@ deps =
     dj30: Django>=3.0, <3.1
     dj31: Django>=3.1, <3.2
     dj32: Django>=3.2, <3.3
+    dj40: Django>=4.0, <5.0
 commands =
     pytest --basetemp="{envtmpdir}" --junitxml="junit/TEST-{envname}.xml" {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     dj30: Django>=3.0, <3.1
     dj31: Django>=3.1, <3.2
     dj32: Django>=3.2, <3.3
-    dj40: Django>=4.0, <5.0
+    dj40: Django>=4.0, <4.1
 commands =
     pytest --basetemp="{envtmpdir}" --junitxml="junit/TEST-{envname}.xml" {posargs}
 


### PR DESCRIPTION
Add Django 4.0.0 compatibility.

* Django template tags `ifequal` and `ifnotequal` have been deprecated since 1.2. Change all templates to use `if`
* Django 3.0.0 deprecated urlquote and 4.0.0 removed it. Switch to use urllib.parse.quote()
* Django 3.1 deprecated `url` and 4.0.0 removed it. Switch to use `django.urls.re_path()`
* Drop support for < Django1.5 (its been end of life since September 2, 2014 
* Remove `providing_args` from signal definitions. Its purely documentational and has been removed in Django 4.0.0 
* `smart_text` was deprecated in Django 3.0 and removed in 4.0. Switch to `smart_str`

This should make the package Django 4.0.0 compatible.

According to https://github.com/stephenmcd/filebrowser-safe/blob/master/README.rst#contributing this project follows Mezzanine's Contribution Guidelines but this repo does not have `AUTHORS` file. Not sure if it should be added so I left it out.