### PR TITLE
fix: added exception to fix EXTRA_MODEL_FIELDS compatability

### DIFF
--- a/filebrowser_safe/functions.py
+++ b/filebrowser_safe/functions.py
@@ -5,13 +5,14 @@ import warnings
 from time import gmtime, localtime, strftime, time
 
 from django.conf import settings as dj_settings
+from django.core.exceptions import AppRegistryNotReady
 from django.core.files.storage import default_storage
 
 from filebrowser_safe import settings as fb_settings
 
 try:
     from mezzanine.utils.sites import current_site_id
-except ImportError:
+except (AppRegistryNotReady, ImportError) as e:
     # TODO: filebrowser-safe should not rely on `current_site_id` at all since its
     # provided by Mezzanine.
     #


### PR DESCRIPTION
Using mezzanine EXTRA_MODEL_FIELDS raises an AppRegistryNotReady exception, which is circumvented by this. This change fixes this issue: https://github.com/stephenmcd/filebrowser-safe/issues/143