### PR TITLE
URL_FILEBROWSER_MEDIA can't use other storages

### DIFF
--- a/filebrowser_safe/fields.py
+++ b/filebrowser_safe/fields.py
@@ -7,6 +7,7 @@ from django.db.models.fields import Field
 from django.db.models.fields.files import FileDescriptor
 from django.forms.widgets import Input
 from django.template.loader import render_to_string
+from django.templatetags.static import static
 from django.utils.encoding import smart_str
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
@@ -20,7 +21,7 @@ class FileBrowseWidget(Input):
     input_type = "text"
 
     class Media:
-        js = (os.path.join(fb_settings.URL_FILEBROWSER_MEDIA, "js/AddFileBrowser.js"),)
+        js = (static("filebrowser/js/AddFileBrowser.js"),)
 
     def __init__(self, attrs=None):
         self.directory = attrs.get("directory", "")
@@ -44,7 +45,7 @@ class FileBrowseWidget(Input):
                 default_storage.makedirs(fullpath)
         final_attrs = dict(type=self.input_type, name=name, **attrs)
         final_attrs["search_icon"] = (
-            fb_settings.URL_FILEBROWSER_MEDIA + "img/filebrowser_icon_show.gif"
+            static("filebrowser/img/filebrowser_icon_show.gif")
         )
         final_attrs["directory"] = directory
         final_attrs["extensions"] = self.extensions

--- a/filebrowser_safe/functions.py
+++ b/filebrowser_safe/functions.py
@@ -174,7 +174,6 @@ def get_settings_var():
     settings_var["MEDIA_URL"] = fb_settings.MEDIA_URL
     settings_var["DIRECTORY"] = get_directory()
     # FileBrowser
-    settings_var["URL_FILEBROWSER_MEDIA"] = fb_settings.URL_FILEBROWSER_MEDIA
     settings_var["PATH_FILEBROWSER_MEDIA"] = fb_settings.PATH_FILEBROWSER_MEDIA
     # TinyMCE
     settings_var["URL_TINYMCE"] = fb_settings.URL_TINYMCE

--- a/filebrowser_safe/settings.py
+++ b/filebrowser_safe/settings.py
@@ -20,12 +20,6 @@ MEDIA_URL = getattr(settings, "FILEBROWSER_MEDIA_URL", settings.MEDIA_URL)
 # DO NOT USE A SLASH AT THE BEGINNING, DO NOT FORGET THE TRAILING SLASH AT THE END.
 DIRECTORY = getattr(settings, "FILEBROWSER_DIRECTORY", "uploads/")
 
-# The URL/PATH to your filebrowser media-files.
-URL_FILEBROWSER_MEDIA = getattr(
-    settings,
-    "FILEBROWSER_URL_FILEBROWSER_MEDIA",
-    "%sfilebrowser/" % settings.STATIC_URL,
-)
 PATH_FILEBROWSER_MEDIA = getattr(
     settings,
     "FILEBROWSER_PATH_FILEBROWSER_MEDIA",

--- a/filebrowser_safe/templates/filebrowser/include/filelisting.html
+++ b/filebrowser_safe/templates/filebrowser/include/filelisting.html
@@ -17,7 +17,7 @@ h1 {margin:-30px 0 15px 0;}
         {% if selectable %}
         <a href="javascript://" onclick="FileSubmit('{{ file.path }}', '{{ file.url }}', '{{ settings_var.MEDIA_URL }}{% if file.filetype == 'Image' %}{% thumbnail file.path 60 60 %}{% else %}{{ file.path }}{% endif %}', '{{ file.filetype }}');" class="fb_selectlink" title="{% trans 'Select' %}"></a>
         {% else %}
-        <img src="{{ settings_var.URL_FILEBROWSER_MEDIA }}img/filebrowser_icon_select_disabled.gif" width="23" height="17" />
+        <img src="{% static 'filebrowser/img/filebrowser_icon_select_disabled.gif' %}" width="23" height="17" />
         {% endif %}
     </td>
     {% endif %}
@@ -31,7 +31,7 @@ h1 {margin:-30px 0 15px 0;}
         {% if selectable %}
         <a href="javascript:FileBrowserDialogue.fileSubmit('{{ file.url|escapejs }}');" class="fb_selectlink" title="{% trans 'Select File' %}"></a>
         {% else %}
-        <img src="{{ settings_var.URL_FILEBROWSER_MEDIA }}img/filebrowser_icon_select_disabled.gif" width="23" height="17" />
+        <img src="{% static 'filebrowser/img/filebrowser_icon_select_disabled.gif' %}" width="23" height="17" />
         {% endif %}
     </td>
     {% endif %}
@@ -45,7 +45,7 @@ h1 {margin:-30px 0 15px 0;}
         {% if selectable %}
         <a href="#" onclick="OpenFile(ProtectPath('{{ file.url|escapejs }}'));return false;" class="fb_selectlink" title="{% trans 'Select File' %}"></a>
         {% else %}
-        <img src="{{ settings_var.URL_FILEBROWSER_MEDIA }}img/filebrowser_icon_select_disabled.gif" width="23" height="17" />
+        <img src="{% static 'filebrowser/img/filebrowser_icon_select_disabled.gif' %}" width="23" height="17" />
         {% endif %}
     </td>
     {% endif %}
@@ -59,15 +59,16 @@ h1 {margin:-30px 0 15px 0;}
         {% if selectable %}
         <a href="#" rel="{{ file.url|escape }}" class="fb_selectlink" title="{% trans 'Select File' %}"></a>
         {% else %}
-        <img src="{{ settings_var.URL_FILEBROWSER_MEDIA }}img/filebrowser_icon_select_disabled.gif" width="23" height="17" />
+        <img src="{% static 'filebrowser/img/filebrowser_icon_select_disabled.gif' %}" width="23" height="17" />
         {% endif %}
     </td>
     {% endif %}
     {% endif %}
 
     <!-- FILEICON -->
-    <td class="fb_icon"><img src="{{ settings_var.URL_FILEBROWSER_MEDIA }}img/filebrowser_type_{{ file.filetype|lower }}.gif" /></td>
-
+    {% with 'filebrowser/'|add:{{ settings_var.URL_FILEBROWSER_MEDIA }}|add:'img/filebrowser_type_'|add:{{ file.filetype|lower }}|add:'.gif' as fileicon  %}
+    <td class="fb_icon"><img src="{% static fileicon %} /></td>
+    {% endwith %}
     <!-- THUMBNAIL -->
     {% if results_var.images_total %}
     <td class="fb_icon">

--- a/filebrowser_safe/templates/filebrowser/include/filelisting.html
+++ b/filebrowser_safe/templates/filebrowser/include/filelisting.html
@@ -66,9 +66,7 @@ h1 {margin:-30px 0 15px 0;}
     {% endif %}
 
     <!-- FILEICON -->
-    {% with 'filebrowser/'|add:{{ settings_var.URL_FILEBROWSER_MEDIA }}|add:'img/filebrowser_type_'|add:{{ file.filetype|lower }}|add:'.gif' as fileicon  %}
-    <td class="fb_icon"><img src="{% static fileicon %} /></td>
-    {% endwith %}
+    <td class="fb_icon"><img src="{% get_filetype_icon file.filetype %}" /></td>
     <!-- THUMBNAIL -->
     {% if results_var.images_total %}
     <td class="fb_icon">

--- a/filebrowser_safe/templates/filebrowser/index.html
+++ b/filebrowser_safe/templates/filebrowser/index.html
@@ -7,7 +7,7 @@
 {% block stylesheets %}
     {{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static "grappelli/css/changelist.css" %}" />
-    <link rel="stylesheet" type="text/css" href="{{ settings_var.URL_FILEBROWSER_MEDIA }}css/filebrowser.css" />
+    <link rel="stylesheet" type="text/css" href="{% static 'filebrowser/css/filebrowser.css' %}" />
 {% endblock %}
 
 <!-- JAVASCRIPTS -->
@@ -15,21 +15,21 @@
 {{ block.super }}
 
 {% if query.pop == '1' %} <!-- FileBrowseField -->
-<script language="javascript" type="text/javascript" src="{{ settings_var.URL_FILEBROWSER_MEDIA }}js/FB_FileBrowseField.js"></script>
+<script language="javascript" type="text/javascript" src="{% static 'filebrowser/js/FB_FileBrowseField.js' %}"></script>
 {% endif %}
 
 {% if query.pop == '2' %} <!-- TinyMCE < 4 -->
 <script language="javascript" type="text/javascript" src="{{ settings_var.URL_TINYMCE }}tiny_mce_popup.js"></script>
-<script language="javascript" type="text/javascript" src="{{ settings_var.URL_FILEBROWSER_MEDIA }}js/FB_TinyMCE.js"></script>
+<script language="javascript" type="text/javascript" src="{% static 'filebrowser/js/FB_TinyMCE.js' %}"></script>
 {% if query.mce_rdomain %}<script language="javascript">document.domain = "{{ query.mce_rdomain }}"</script>{% endif %}
 {% endif %}
 
 {% if query.pop == '3' %} <!-- CKeditor (former "FCKeditor") -->
-<script language="javascript" type="text/javascript" src="{{ settings_var.URL_FILEBROWSER_MEDIA }}js/FB_CKEditor.js"></script>
+<script language="javascript" type="text/javascript" src="{% static 'filebrowser/js/FB_CKEditor.js' %}"></script>
 {% endif %}
 
 {% if query.pop == '5' %} <!-- TinyMCE 4 -->
-<script language="javascript" type="text/javascript" src="{{ settings_var.URL_FILEBROWSER_MEDIA }}js/FB_TinyMCE4.js"></script>
+<script language="javascript" type="text/javascript" src="{% static 'filebrowser/js/FB_TinyMCE4.js' %}"></script>
 {% endif %}
 
 <script type="text/javascript" src="{% static "grappelli/js/admin/Changelist.js" %}"></script>
@@ -43,7 +43,7 @@
 
 {% block rtl_styles %}
 {{ block.super }}
-<link rel="stylesheet" type="text/css" href="{{ settings_var.URL_FILEBROWSER_MEDIA }}css/rtl.css" />
+<link rel="stylesheet" type="text/css" href="{% static 'filebrowser/css/rtl.css' %}" />
 {% endblock %}
 
 <!-- COLTYPE/BODYCLASS -->

--- a/filebrowser_safe/templates/filebrowser/makedir.html
+++ b/filebrowser_safe/templates/filebrowser/makedir.html
@@ -7,12 +7,12 @@
 {% block stylesheets %}
     {{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static "grappelli/css/forms.css" %}" />
-    <link rel="stylesheet" type="text/css" href="{{ settings_var.URL_FILEBROWSER_MEDIA }}css/filebrowser.css" />
+    <link rel="stylesheet" type="text/css" href="{% static 'filebrowser/css/filebrowser.css' %}" />
 {% endblock %}
 
 {% block rtl_styles %}
 {{ block.super }}
-<link rel="stylesheet" type="text/css" href="{{ settings_var.URL_FILEBROWSER_MEDIA }}css/rtl.css" />
+<link rel="stylesheet" type="text/css" href="{% static 'filebrowser/css/rtl.css' %}" />
 {% endblock %}
 
 <!-- COLTYPE/BODYCLASS -->

--- a/filebrowser_safe/templates/filebrowser/rename.html
+++ b/filebrowser_safe/templates/filebrowser/rename.html
@@ -7,12 +7,12 @@
 {% block stylesheets %}
     {{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static "grappelli/css/forms.css" %}" />
-    <link rel="stylesheet" type="text/css" href="{{ settings_var.URL_FILEBROWSER_MEDIA }}css/filebrowser.css" />
+    <link rel="stylesheet" type="text/css" href="{% static 'filebrowser/css/filebrowser.css' %}" />
 {% endblock %}
 
 {% block rtl_styles %}
 {{ block.super }}
-<link rel="stylesheet" type="text/css" href="{{ settings_var.URL_FILEBROWSER_MEDIA }}css/rtl.css" />
+<link rel="stylesheet" type="text/css" href="{% static 'filebrowser/css/rtl.css' %}" />
 {% endblock %}
 
 <!-- COLTYPE/BODYCLASS -->

--- a/filebrowser_safe/templates/filebrowser/upload.html
+++ b/filebrowser_safe/templates/filebrowser/upload.html
@@ -7,18 +7,18 @@
 {% block stylesheets %}
     {{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static 'grappelli/css/forms.css' %}" />
-    <link rel="stylesheet" type="text/css" href="{{ settings_var.URL_FILEBROWSER_MEDIA }}css/filebrowser.css" />
+    <link rel="stylesheet" type="text/css" href="{% static 'filebrowser/css/filebrowser.css' %}" />
 {% endblock %}
 
 {% block rtl_styles %}
 {{ block.super }}
-<link rel="stylesheet" type="text/css" href="{{ settings_var.URL_FILEBROWSER_MEDIA }}css/rtl.css" />
+<link rel="stylesheet" type="text/css" href="{% static 'filebrowser/css/rtl.css' %}" />
 {% endblock %}
 
 <!-- JAVASCRIPTS -->
 {% block extrahead %}
     {{ block.super }}
-    <script type="text/javascript" src="{{ settings_var.URL_FILEBROWSER_MEDIA }}js/upload.js"></script>
+    <script type="text/javascript" src="{% static 'filebrowser/js/upload.js' %}"></script>
 {% endblock extrahead %}
 
 <!-- COLTYPE/BODYCLASS -->

--- a/filebrowser_safe/templatetags/fb_tags.py
+++ b/filebrowser_safe/templatetags/fb_tags.py
@@ -1,6 +1,7 @@
 import warnings
 
 from django import template
+from django.templatetags.static import static
 
 from urllib.parse import quote
 
@@ -184,3 +185,7 @@ def allowed_extensions_list(separator=","):
 
 
 register.simple_tag(allowed_extensions_list)
+
+@register.simple_tag
+def get_filetype_icon(filetype):
+    return static(f'filebrowser/img/filebrowser_type_{filetype.lower()}.gif')


### PR DESCRIPTION
Static generation of admin media url won't work with whitenoise or other cdn (since the only available assets are the ones containing hashes in their names)